### PR TITLE
[Fix] Register port group properly in the dictionary when created.

### DIFF
--- a/Operators/Utils/OscConnectionManager.cs
+++ b/Operators/Utils/OscConnectionManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Rug.Osc;
@@ -54,6 +54,8 @@ namespace Operators.Utils
                                    Port = port,
                                    Receiver = newReceiver,
                                };
+
+            _groupsByPort.Add(port, newGroup);
 
             var thread = new Thread(new ThreadStart(newGroup.ThreadProc));
             newGroup.Thread = thread;


### PR DESCRIPTION
Was preventing to create multiple OSC Input instances
fixes #87