### PR TITLE
Nested time clip zooming without local time handling

### DIFF
--- a/T3/Gui/Graph/AnnotationElement.cs
+++ b/T3/Gui/Graph/AnnotationElement.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ImGuiNET;
@@ -240,7 +240,7 @@ namespace T3.Gui.Graph
             }
 
             var newDragPos = ImGui.GetMousePos() - _dragStartDelta;
-            var newDragPosInCanvas = GraphCanvas.Current.InverseTransformPosition(newDragPos);
+            var newDragPosInCanvas = GraphCanvas.Current.InverseTransformPositionFloat(newDragPos);
             var moveDeltaOnCanvas = newDragPosInCanvas - draggedNode.PosOnCanvas;
 
             // Drag selection

--- a/T3/Gui/Graph/GraphCanvas.cs
+++ b/T3/Gui/Graph/GraphCanvas.cs
@@ -39,11 +39,19 @@ namespace T3.Gui.Graph
         public GraphCanvas(GraphWindow window, List<Guid> idPath)
         {
             _window = window;
-            SetComposition(idPath, Transition.JumpIn);
+            SetComposition(idPath, ICanvas.Transition.JumpIn);
         }
 
-        public void SetComposition(List<Guid> childIdPath, Transition transition)
+        public void SetComposition(List<Guid> childIdPath, ICanvas.Transition transition)
         {
+            // zoom timeline out if necessary
+            if (transition == ICanvas.Transition.JumpOut)
+            {
+                var primaryGraphWindow = GraphWindow.GetVisibleInstances().FirstOrDefault();
+                primaryGraphWindow?.CurrentTimeLine?.UpdateScaleAndTranslation(primaryGraphWindow.GraphCanvas.CompositionOp,
+                                                                              transition);
+            }
+
             var previousFocusOnScreen = WindowPos + WindowSize / 2;
 
             var previousInstanceWasSet = _compositionPath != null && _compositionPath.Count > 0;
@@ -85,6 +93,13 @@ namespace T3.Gui.Graph
             }
 
             SetScopeWithTransition(newProps.Scale, newProps.Scroll, previousFocusOnScreen, transition);
+
+            if (transition == ICanvas.Transition.JumpIn)
+            {
+                var primaryGraphWindow = GraphWindow.GetVisibleInstances().FirstOrDefault();
+                primaryGraphWindow?.CurrentTimeLine?.UpdateScaleAndTranslation(primaryGraphWindow.GraphCanvas.CompositionOp,
+                                                                               transition);
+            }
         }
 
         public void SetCompositionToChildInstance(Instance instance)
@@ -102,7 +117,7 @@ namespace T3.Gui.Graph
             newPath.Add(instance.SymbolChildId);
             NodeSelection.Clear();
             TimeLineCanvas.Current?.ClearSelection();
-            SetComposition(newPath, Transition.JumpIn);
+            SetComposition(newPath, ICanvas.Transition.JumpIn);
         }
 
         public void SetCompositionToParentInstance(Instance instance)
@@ -128,7 +143,7 @@ namespace T3.Gui.Graph
             if (shortenedPath.Count() == _compositionPath.Count())
                 throw new ArgumentException("Can't SetCompositionToParentInstance because Instance is not a parent of current composition");
 
-            SetComposition(shortenedPath, Transition.JumpOut);
+            SetComposition(shortenedPath, ICanvas.Transition.JumpOut);
             NodeSelection.Clear();
             TimeLineCanvas.Current?.ClearSelection();
             var previousCompChildUi = SymbolUiRegistry.Entries[CompositionOp.Symbol.Id].ChildUis

--- a/T3/Gui/Graph/GraphCanvas.cs
+++ b/T3/Gui/Graph/GraphCanvas.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -306,7 +306,7 @@ namespace T3.Gui.Graph
                     if (droppedOnBackground)
                     {
                         ConnectionMaker.InitSymbolBrowserAtPosition(SymbolBrowser,
-                                                                    InverseTransformPosition(ImGui.GetIO().MousePos));
+                                                                    InverseTransformPositionFloat(ImGui.GetIO().MousePos));
                     }
                     else
                     {
@@ -466,7 +466,7 @@ namespace T3.Gui.Graph
 
                         var symbol = SymbolRegistry.Entries[guid];
                         var parent = CompositionOp.Symbol;
-                        var posOnCanvas = InverseTransformPosition(ImGui.GetMousePos());
+                        var posOnCanvas = InverseTransformPositionFloat(ImGui.GetMousePos());
                         var childUi = NodeOperations.CreateInstance(symbol, parent, posOnCanvas);
 
                         var instance = CompositionOp.Children.Single(child => child.SymbolChildId == childUi.Id);
@@ -726,7 +726,7 @@ namespace T3.Gui.Graph
             {
                 if (ImGui.MenuItem("Add Node...", "TAB", false,true))
                 {
-                    SymbolBrowser.OpenAt(InverseTransformPosition(ImGui.GetMousePos()), null, null, false, null);
+                    SymbolBrowser.OpenAt(InverseTransformPositionFloat(ImGui.GetMousePos()), null, null, false, null);
                 }
 
                 if (ImGui.MenuItem("Add input parameter..."))
@@ -761,7 +761,7 @@ namespace T3.Gui.Graph
         private void AddAnnotation()
         {
             var size = new Vector2(100, 140);
-            var posOnCanvas = InverseTransformPosition(ImGui.GetMousePos());
+            var posOnCanvas = InverseTransformPositionFloat(ImGui.GetMousePos());
             var area = new ImRect(posOnCanvas, posOnCanvas + size);
                     
             if (NodeSelection.IsAnythingSelected())
@@ -908,7 +908,7 @@ namespace T3.Gui.Graph
                                                     selectedChildren,
                                                     selectedAnnotations,
                                                     newContainerUi,
-                                                    InverseTransformPosition(ImGui.GetMousePos()));
+                                                    InverseTransformPositionFloat(ImGui.GetMousePos()));
             cmd.Do();
 
             using (var writer = new StringWriter())
@@ -960,7 +960,7 @@ namespace T3.Gui.Graph
                                                             null,
                                                             containerSymbolUi.Annotations.Values.ToList(),
                                                             compositionSymbolUi,
-                                                            InverseTransformPosition(ImGui.GetMousePos()));
+                                                            InverseTransformPositionFloat(ImGui.GetMousePos()));
                     cmd.Do(); // FIXME: Shouldn't this be UndoRedoQueue.AddAndExecute() ? 
                     SymbolUiRegistry.Entries.Remove(containerSymbolUi.Symbol.Id);
                     SymbolRegistry.Entries.Remove(containerSymbol.Id);

--- a/T3/Gui/Graph/GraphWindow.cs
+++ b/T3/Gui/Graph/GraphWindow.cs
@@ -359,8 +359,8 @@ namespace T3.Gui.Graph
                         }
                         
                         // Draw View Area
-                        var viewMinInCanvas = canvas.InverseTransformPosition(Vector2.Zero);
-                        var viewMaxInCanvas = canvas.InverseTransformPosition(canvas.WindowSize);
+                        var viewMinInCanvas = canvas.InverseTransformPositionFloat(Vector2.Zero);
+                        var viewMaxInCanvas = canvas.InverseTransformPositionFloat(canvas.WindowSize);
                         
                         var min2 = (viewMinInCanvas - boundsMin) / boundsSize * mapSize + mapMin;
                         var max2 = (viewMaxInCanvas - boundsMin) / boundsSize * mapSize + mapMin;

--- a/T3/Gui/Graph/GraphWindow.cs
+++ b/T3/Gui/Graph/GraphWindow.cs
@@ -550,6 +550,8 @@ namespace T3.Gui.Graph
 
         private readonly TimeLineCanvas _timeLineCanvas;
 
+        public TimeLineCanvas CurrentTimeLine => _timeLineCanvas;
+
         private static readonly EditSymbolDescriptionDialog EditDescriptionDialog = new EditSymbolDescriptionDialog();
     }
 }

--- a/T3/Gui/Graph/Interaction/ConnectionMaker.cs
+++ b/T3/Gui/Graph/Interaction/ConnectionMaker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ImGuiNET;
@@ -856,7 +856,7 @@ namespace T3.Gui.Graph
                         && ImGui.GetMouseDragDelta(ImGuiMouseButton.Left).Length() < UserSettings.Config.ClickThreshold
                         )
                     {
-                        var posOnScreen = graphCanvas.InverseTransformPosition(_bestMatchYetForCurrentFrame.PositionOnScreen) - SymbolChildUi.DefaultOpSize / 2;
+                        var posOnScreen = graphCanvas.InverseTransformPositionFloat(_bestMatchYetForCurrentFrame.PositionOnScreen) - SymbolChildUi.DefaultOpSize / 2;
 
                         SplitConnectionWithSymbolBrowser(graphCanvas.CompositionOp.Symbol,
                                                          graphCanvas.SymbolBrowser,

--- a/T3/Gui/Graph/Interaction/NodeOperations.cs
+++ b/T3/Gui/Graph/Interaction/NodeOperations.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -560,7 +560,7 @@ namespace T3.Gui.Graph.Interaction
             }
 
             // Create instance
-            var mousePos = GraphCanvas.Current.InverseTransformPosition(ImGui.GetMousePos());
+            var mousePos = GraphCanvas.Current.InverseTransformPositionFloat(ImGui.GetMousePos());
             var addCommand = new AddSymbolChildCommand(compositionUi.Symbol, newSymbol.Id) { PosOnCanvas = mousePos };
             UndoRedoStack.AddAndExecute(addCommand);
 

--- a/T3/Gui/Graph/Interaction/SelectableNodeMovement.cs
+++ b/T3/Gui/Graph/Interaction/SelectableNodeMovement.cs
@@ -246,7 +246,7 @@ namespace T3.Gui.Graph.Interaction
             }
 
             var newDragPos = ImGui.GetMousePos() - _dragStartDelta;
-            var newDragPosInCanvas = GraphCanvas.Current.InverseTransformPosition(newDragPos);
+            var newDragPosInCanvas = GraphCanvas.Current.InverseTransformPositionFloat(newDragPos);
 
             var bestDistanceInCanvas = float.PositiveInfinity;
             var targetSnapPositionInCanvas = Vector2.Zero;

--- a/T3/Gui/Graph/Interaction/SymbolBrowser.cs
+++ b/T3/Gui/Graph/Interaction/SymbolBrowser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -64,7 +64,7 @@ namespace T3.Gui.Graph.Interaction
                 }
                 else
                 {
-                    OpenAt(GraphCanvas.Current.InverseTransformPosition(ImGui.GetIO().MousePos + new Vector2(-4, -20)), null, null, false, null);
+                    OpenAt(GraphCanvas.Current.InverseTransformPositionFloat(ImGui.GetIO().MousePos + new Vector2(-4, -20)), null, null, false, null);
                 }
 
                 return;

--- a/T3/Gui/InputUi/CombinedInputs/CurveInputEditing.cs
+++ b/T3/Gui/InputUi/CombinedInputs/CurveInputEditing.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -160,7 +160,7 @@ namespace t3.Gui.InputUi.CombinedInputs
                     StartDragCommand();
                 }
 
-                var newDragPosition = _singleCurveCanvas.InverseTransformPosition(ImGui.GetIO().MousePos);
+                var newDragPosition = _singleCurveCanvas.InverseTransformPositionFloat(ImGui.GetIO().MousePos);
                 double u = newDragPosition.X;
                 var enableSnapping = ImGui.GetIO().KeyShift;
                 if(enableSnapping)

--- a/T3/Gui/Interaction/Camera/CameraInteraction.cs
+++ b/T3/Gui/Interaction/Camera/CameraInteraction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using ImGuiNET;
 using T3.Core.IO;
@@ -38,10 +38,11 @@ namespace t3.Gui.Interaction.Camera
                 _lastCameraNode = camera;
             }
 
-            if (allowCameraInteraction && ImGui.IsWindowFocused() && ImGui.IsWindowHovered())
+            if (allowCameraInteraction && ImGui.IsWindowHovered())
             {
                 ManipulateCameraByMouse();
-                ManipulateCameraByKeyboard();
+                if (ImGui.IsWindowFocused())
+                    ManipulateCameraByKeyboard();
             }
 
             var frameTime = ImGui.GetTime();

--- a/T3/Gui/Interaction/ScalableCanvas.cs
+++ b/T3/Gui/Interaction/ScalableCanvas.cs
@@ -146,6 +146,11 @@ namespace T3.Gui.Interaction
                               InverseTransformPositionFloat(screenRect.Max));
         }
 
+        public virtual void UpdateScaleAndTranslation(Instance compositionOp, ICanvas.Transition transition)
+        {
+            // by default do nothing, overide in subclasses
+        }
+
         /// <summary>
         /// Transform a canvas position to relative position within ImGui-window (e.g. to set ImGui context) 
         /// </summary>
@@ -160,11 +165,9 @@ namespace T3.Gui.Interaction
 
         public Vector2 Scale { get; protected set; } = Vector2.One;
         protected Vector2 ScaleTarget = Vector2.One;
-        protected float NestedTimeScale { get; private set; } = 1f;
 
         public Vector2 Scroll { get; protected set; } = new Vector2(0.0f, 0.0f);
         protected Vector2 ScrollTarget = new Vector2(0.0f, 0.0f);
-        protected float NestedTimeScroll { get; private set; } = 0f;
         #endregion
 
         public Scope GetTargetScope()
@@ -299,14 +302,7 @@ namespace T3.Gui.Interaction
             }
         }
 
-        public enum Transition
-        {
-            JumpIn,
-            JumpOut,
-            Undefined,
-        }
-
-        protected void SetScopeWithTransition(Vector2 scale, Vector2 scroll, Vector2 previousFocusOnScreen, Transition transition)
+        protected void SetScopeWithTransition(Vector2 scale, Vector2 scroll, Vector2 previousFocusOnScreen, ICanvas.Transition transition)
         {
             if (float.IsInfinity(scale.X) || float.IsNaN(scale.X)
                                           || float.IsInfinity(scale.Y) || float.IsNaN(scale.Y)
@@ -323,13 +319,13 @@ namespace T3.Gui.Interaction
 
             switch (transition)
             {
-                case Transition.JumpIn:
+                case ICanvas.Transition.JumpIn:
                     Scale = ScaleTarget * 0.3f;
                     var sizeOnCanvas = WindowSize / Scale;
                     Scroll = ScrollTarget - sizeOnCanvas / 2;
                     break;
 
-                case Transition.JumpOut:
+                case ICanvas.Transition.JumpOut:
                     Scale = ScaleTarget * 3f;
                     var sizeOnCanvas2 = WindowSize / Scale;
                     Scroll = ScrollTarget + sizeOnCanvas2 / 2;
@@ -540,8 +536,6 @@ namespace T3.Gui.Interaction
         public bool UsingParentCanvas => GraphCanvas.Current != this && GraphCanvas.Current != null;
         public Vector2 ParentScale => UsingParentCanvas ? GraphCanvas.Current.ScaleTarget : Vector2.One;
         public Vector2 ParentScroll => UsingParentCanvas ? GraphCanvas.Current.ScrollTarget : Vector2.Zero;
-        public float ParentTimeScale => UsingParentCanvas ? GraphCanvas.Current.NestedTimeScale : 1f;
-        public float ParentTimeScroll => UsingParentCanvas ? GraphCanvas.Current.NestedTimeScroll : 0f;
 
         public struct Scope
         {

--- a/T3/Gui/Interaction/ScalableCanvas.cs
+++ b/T3/Gui/Interaction/ScalableCanvas.cs
@@ -109,7 +109,8 @@ namespace T3.Gui.Interaction
         /// </summary>
         public Vector2 TransformDirection(Vector2 vectorInCanvas)
         {
-            return vectorInCanvas * Scale;
+            return TransformPositionFloat(vectorInCanvas) -
+                   TransformPositionFloat(new Vector2(0, 0));
         }
 
         public Vector2 TransformDirectionFloored(Vector2 vectorInCanvas)

--- a/T3/Gui/Interaction/ScalableCanvas.cs
+++ b/T3/Gui/Interaction/ScalableCanvas.cs
@@ -157,11 +157,11 @@ namespace T3.Gui.Interaction
         public Vector2 WindowPos { get; private set; }
         public Vector2 WindowSize { get; private set; }
 
-        public Vector2 Scale { get; private set; } = Vector2.One;
+        public Vector2 Scale { get; protected set; } = Vector2.One;
         protected Vector2 ScaleTarget = Vector2.One;
         protected float NestedTimeScale { get; private set; } = 1f;
 
-        public Vector2 Scroll { get; private set; } = new Vector2(0.0f, 0.0f);
+        public Vector2 Scroll { get; protected set; } = new Vector2(0.0f, 0.0f);
         protected Vector2 ScrollTarget = new Vector2(0.0f, 0.0f);
         protected float NestedTimeScroll { get; private set; } = 0f;
         #endregion

--- a/T3/Gui/Interaction/WithCurves/CurveEditCanvas.cs
+++ b/T3/Gui/Interaction/WithCurves/CurveEditCanvas.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using ImGuiNET;
@@ -83,7 +83,8 @@ namespace T3.Gui.Interaction.WithCurves
             {
                 var sampledValue = (float)curve.GetSampledValue(hoverTime);
                 var posOnCanvas = new Vector2(hoverTime, sampledValue);
-                var posOnScreen = TransformPosition(posOnCanvas) - new Vector2(KeyframeIconWidth / 2 + 1, KeyframeIconWidth / 2 + 1);
+                var posOnScreen = TransformPosition(posOnCanvas)
+                                - new Vector2(KeyframeIconWidth / 2 + 1, KeyframeIconWidth / 2 + 1);
                 Icons.Draw(Icon.CurveKeyframe, posOnScreen);
                 var drawlist = ImGui.GetWindowDrawList();
                 drawlist.AddText(posOnScreen + Vector2.One*20, Color.Gray, $"Insert at\n{hoverTime:0.00}  {sampledValue:0.00}");

--- a/T3/Gui/UiHelpers/ICanvas.cs
+++ b/T3/Gui/UiHelpers/ICanvas.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Numerics;
+using T3.Core.Operator;
 using T3.Gui.Selection;
 using UiHelpers;
 
@@ -29,7 +30,7 @@ namespace T3.Gui.UiHelpers
         /// <summary>
         /// Get screen position applying canvas zoom and scrolling to graph position (e.g. of an Operator) 
         /// </summary>
-        Vector2 InverseTransformPosition(Vector2 screenPos);
+        Vector2 InverseTransformPositionFloat(Vector2 screenPos);
 
         float InverseTransformX(float x);
         float TransformX(float x);

--- a/T3/Gui/UiHelpers/ICanvas.cs
+++ b/T3/Gui/UiHelpers/ICanvas.cs
@@ -19,6 +19,11 @@ namespace T3.Gui.UiHelpers
         /// <summary>
         /// Get screen position applying canvas zoom and scrolling to graph position (e.g. of an Operator) 
         /// </summary>
+        Vector2 TransformPositionFloat(Vector2 posOnCanvas);
+
+        /// <summary>
+        /// Get integer-aligned screen position applying canvas zoom and scrolling to graph position (e.g. of an Operator) 
+        /// </summary>
         Vector2 TransformPosition(Vector2 posOnCanvas);
 
         /// <summary>

--- a/T3/Gui/UiHelpers/ICanvas.cs
+++ b/T3/Gui/UiHelpers/ICanvas.cs
@@ -57,8 +57,18 @@ namespace T3.Gui.UiHelpers
 
         ImRect InverseTransformRect(ImRect screenRect);
 
-        
-        
+        public enum Transition
+        {
+            JumpIn,
+            JumpOut,
+            Undefined,
+        }
+
+        /// <summary>
+        /// This function is called once when zooming in or out of a time clip canvas
+        /// </summary>
+        void UpdateScaleAndTranslation(Instance compositionOp, Transition transition);
+
         Vector2 Scale { get; }
         Vector2 Scroll { get; }
         Vector2 WindowSize { get; }

--- a/T3/Gui/Windows/Exploration/ExploreVariationCanvas.cs
+++ b/T3/Gui/Windows/Exploration/ExploreVariationCanvas.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ImGuiNET;
@@ -139,7 +139,7 @@ namespace T3.Gui.Windows.Exploration
 
         private GridCell GetScreenRectForGridCell(Vector2 screenPos)
         {
-            var centerInCanvas = InverseTransformPosition(screenPos);
+            var centerInCanvas = InverseTransformPositionFloat(screenPos);
             return new GridCell(
                                 (int)(centerInCanvas.X / _thumbnailSize.X),
                                 (int)(centerInCanvas.Y / _thumbnailSize.Y));
@@ -201,14 +201,14 @@ namespace T3.Gui.Windows.Exploration
         {
             var contentRegion = new ImRect(ImGui.GetWindowContentRegionMin() + ImGui.GetWindowPos(),
                                            ImGui.GetWindowContentRegionMax() + ImGui.GetWindowPos());
-            var centerInCanvas = InverseTransformPosition(contentRegion.GetCenter());
+            var centerInCanvas = InverseTransformPositionFloat(contentRegion.GetCenter());
             _gridFocusIndex.X = (int)(centerInCanvas.X / _thumbnailSize.X);
             _gridFocusIndex.Y = (int)(centerInCanvas.Y / _thumbnailSize.Y);
         }
 
         private void SetGridFocusToMousePos()
         {
-            var centerInCanvas = InverseTransformPosition(ImGui.GetMousePos());
+            var centerInCanvas = InverseTransformPositionFloat(ImGui.GetMousePos());
             _gridFocusIndex.X = (int)(centerInCanvas.X / _thumbnailSize.X);
             _gridFocusIndex.Y = (int)(centerInCanvas.Y / _thumbnailSize.Y);
         }

--- a/T3/Gui/Windows/GraphBookmarkNavigation.cs
+++ b/T3/Gui/Windows/GraphBookmarkNavigation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ImGuiNET;
@@ -120,7 +120,7 @@ namespace T3.Gui.Windows
                 return;
             }
 
-            canvas.SetComposition(bookmark.IdPath, ScalableCanvas.Transition.Undefined);
+            canvas.SetComposition(bookmark.IdPath, ICanvas.Transition.Undefined);
             canvas.SetVisibleRange(bookmark.ViewScope.Scale, bookmark.ViewScope.Scroll);
             //SelectionManager.SetSelection(bookmark.SelectedChildIds);
         }

--- a/T3/Gui/Windows/SymbolLibrary.cs
+++ b/T3/Gui/Windows/SymbolLibrary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ImGuiNET;
 using System.Collections.Generic;
 using System.Linq;
@@ -142,7 +142,7 @@ namespace T3.Gui.Windows
                         if (ImGui.Selectable(symbolChild.ReadableName))
                         {
                             graphWindow?.GraphCanvas.SetComposition(NodeOperations.BuildIdPathForInstance(instanceParent),
-                                                                    ScalableCanvas.Transition.Undefined);
+                                                                    ICanvas.Transition.Undefined);
 
                             var childUi = SymbolUiRegistry.Entries[compositionSymbol.Id].ChildUis.Single(cUi => cUi.Id == instance.SymbolChildId);
                             NodeSelection.SetSelectionToChildUi(childUi, instance);

--- a/T3/Gui/Windows/TimeLine/CurrentTimeMarker.cs
+++ b/T3/Gui/Windows/TimeLine/CurrentTimeMarker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using ImGuiNET;
 using T3.Core.Animation;
@@ -8,7 +8,7 @@ namespace T3.Gui.Windows.TimeLine
 {
     public class CurrentTimeMarker: IValueSnapAttractor
     {
-        public  void Draw(Playback playback)
+        public void Draw(Playback playback)
         {
             if (playback == null)
                 return;
@@ -21,7 +21,6 @@ namespace T3.Gui.Windows.TimeLine
         }
 
         private static readonly Color _shadowColor = new Color(0, 0, 0, 0.4f);
-        
         
         public SnapResult CheckForSnap(double time, float canvasScale)
         {

--- a/T3/Gui/Windows/TimeLine/CurrentTimeMarker.cs
+++ b/T3/Gui/Windows/TimeLine/CurrentTimeMarker.cs
@@ -14,7 +14,7 @@ namespace T3.Gui.Windows.TimeLine
                 return;
             _playback = playback;
 
-            var p = new Vector2(TimeLineCanvas.Current.TransformGlobalTime((float)playback.TimeInBars), 0);
+            var p = new Vector2(TimeLineCanvas.Current.TransformX((float)playback.TimeInBars), 0);
             var drawList = ImGui.GetWindowDrawList();
             drawList.AddRectFilled(p + new Vector2(-1,0), p + new Vector2(2, 2000), _shadowColor);
             drawList.AddRectFilled(p, p + new Vector2(1, 2000), Color.Orange);

--- a/T3/Gui/Windows/TimeLine/DopeSheetArea.cs
+++ b/T3/Gui/Windows/TimeLine/DopeSheetArea.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -289,9 +289,7 @@ namespace T3.Gui.Windows.TimeLine
                             
                             Positions.Add(new Vector2(TimeLineCanvas.Current.TransformX((float)blendU),
                                                        value));
-                            
                         }
-                        
                     } 
 
                     lastValue = MathUtils.RemapAndClamp((float)vDef.Value, maxValue, minValue, layerArea.Min.Y + padding, layerArea.Max.Y - padding);

--- a/T3/Gui/Windows/TimeLine/LayersArea.cs
+++ b/T3/Gui/Windows/TimeLine/LayersArea.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -257,16 +257,16 @@ namespace T3.Gui.Windows.TimeLine
                 var startPosition = position + new Vector2(0, LayerHeight);
                 _drawList.AddBezierCubic(startPosition, 
                                          startPosition + new Vector2(0,verticalOffset),
-                                         startPosition +  new Vector2(horizontalOffset,0),
-                                         startPosition +  new Vector2(horizontalOffset,verticalOffset), 
+                                         startPosition + new Vector2(horizontalOffset,0),
+                                         startPosition + new Vector2(horizontalOffset,verticalOffset), 
                                          _timeRemappingColor,1);
                 
                 horizontalOffset =  TimeLineCanvas.Current.TransformDirection(new Vector2(timeClip.SourceRange.End - timeClip.TimeRange.End,0)).X;
                 var endPosition = position + new Vector2(clipSize.X, LayerHeight);
                 _drawList.AddBezierCubic(endPosition, 
                                          endPosition + new Vector2(0,verticalOffset),
-                                         endPosition +  new Vector2(horizontalOffset,0),
-                                         endPosition +  new Vector2(horizontalOffset,verticalOffset), 
+                                         endPosition + new Vector2(horizontalOffset,0),
+                                         endPosition + new Vector2(horizontalOffset,verticalOffset), 
                                          _timeRemappingColor,1);
                 
             }
@@ -422,10 +422,12 @@ namespace T3.Gui.Windows.TimeLine
             }
 
             var mousePos = ImGui.GetIO().MousePos;
+            var dragContent = ImGui.GetIO().KeyAlt;
+            var referenceRange = (dragContent ? timeClip.SourceRange : timeClip.TimeRange);
             if (_moveClipsCommand == null)
             {
                 var dragStartedAtTime = TimeLineCanvas.Current.InverseTransformX(mousePos.X);
-                _timeWithinDraggedClip = dragStartedAtTime - timeClip.TimeRange.Start;
+                _timeWithinDraggedClip = dragStartedAtTime - referenceRange.Start;
                 _posYInsideDraggedClip = mousePos.Y - position.Y;
                 TimeLineCanvas.Current.StartDragCommand();
             }
@@ -442,14 +444,13 @@ namespace T3.Gui.Windows.TimeLine
 
                     if (_snapHandler.CheckForSnapping(ref newStartTime, TimeLineCanvas.Current.Scale.X))
                     {
-                        TimeLineCanvas.Current.UpdateDragCommand(newStartTime - timeClip.TimeRange.Start, dy);
+                        TimeLineCanvas.Current.UpdateDragCommand(newStartTime - referenceRange.Start, dy);
                         return;
                     }
 
                     var newEndTime = newStartTime + timeClip.TimeRange.Duration;
                     _snapHandler.CheckForSnapping(ref newEndTime, TimeLineCanvas.Current.Scale.X);
-
-                    TimeLineCanvas.Current.UpdateDragCommand(newEndTime - timeClip.TimeRange.End, dy);
+                    TimeLineCanvas.Current.UpdateDragCommand(newEndTime - referenceRange.End, dy);
                     break;
 
                 case HandleDragMode.Start:
@@ -461,7 +462,6 @@ namespace T3.Gui.Windows.TimeLine
                 case HandleDragMode.End:
                     var newDragTime = TimeLineCanvas.Current.InverseTransformX(mousePos.X);
                     _snapHandler.CheckForSnapping(ref newDragTime, TimeLineCanvas.Current.Scale.X);
-
                     TimeLineCanvas.Current.UpdateDragAtEndPointCommand(newDragTime - timeClip.TimeRange.End, 0);
                     break;
 

--- a/T3/Gui/Windows/TimeLine/Raster/BeatTimeRaster.cs
+++ b/T3/Gui/Windows/TimeLine/Raster/BeatTimeRaster.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using T3.Core.Animation;
@@ -22,7 +22,7 @@ namespace T3.Gui.Windows.TimeLine
             }
 
             var scale = TimeLineCanvas.Current.NestedTimeScale;
-            var scroll = TimeLineCanvas.Current.NestedTimeOffset;
+            var scroll = TimeLineCanvas.Current.NestedTimeScroll;
             DrawTimeTicks(scale, scroll / scale, TimeLineCanvas.Current);
         }
 

--- a/T3/Gui/Windows/TimeLine/Raster/BeatTimeRaster.cs
+++ b/T3/Gui/Windows/TimeLine/Raster/BeatTimeRaster.cs
@@ -21,9 +21,9 @@ namespace T3.Gui.Windows.TimeLine
                 ScaleRanges = InitializeTimeScaleDefinitions(UserSettings.Config.TimeRasterDensity * 0.02f);
             }
 
-            var scale = TimeLineCanvas.Current.NestedTimeScale;
-            var scroll = TimeLineCanvas.Current.NestedTimeScroll;
-            DrawTimeTicks(scale, scroll / scale, TimeLineCanvas.Current);
+            var scale = TimeLineCanvas.Current.Scale.X;
+            var scroll = TimeLineCanvas.Current.Scroll.X;
+            DrawTimeTicks(scale, scroll, TimeLineCanvas.Current);
         }
 
         protected override string BuildLabel(Raster raster, double timeInBars)

--- a/T3/Gui/Windows/TimeLine/Raster/SiTimeRaster.cs
+++ b/T3/Gui/Windows/TimeLine/Raster/SiTimeRaster.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using ImGuiNET;
 using T3.Core.Animation;
@@ -21,7 +21,7 @@ namespace T3.Gui.Windows.TimeLine.Raster
             }
 
             var scale = TimeLineCanvas.Current.NestedTimeScale * playback.Bpm / 120;
-            var scroll = TimeLineCanvas.Current.NestedTimeOffset;
+            var scroll = TimeLineCanvas.Current.NestedTimeScroll;
 
             DrawTimeTicks(scale, scroll / scale, TimeLineCanvas.Current);
         }

--- a/T3/Gui/Windows/TimeLine/Raster/SiTimeRaster.cs
+++ b/T3/Gui/Windows/TimeLine/Raster/SiTimeRaster.cs
@@ -20,10 +20,10 @@ namespace T3.Gui.Windows.TimeLine.Raster
                 _initializedDensity = UserSettings.Config.TimeRasterDensity;
             }
 
-            var scale = TimeLineCanvas.Current.NestedTimeScale * playback.Bpm / 120;
-            var scroll = TimeLineCanvas.Current.NestedTimeScroll;
+            var scale = TimeLineCanvas.Current.Scale.X * playback.Bpm / 120f;
+            var scroll = TimeLineCanvas.Current.Scroll.X / playback.Bpm * 120f;
 
-            DrawTimeTicks(scale, scroll / scale, TimeLineCanvas.Current);
+            DrawTimeTicks(scale, scroll, TimeLineCanvas.Current);
         }
 
         private const double Epsilon = 0.01f;

--- a/T3/Gui/Windows/TimeLine/Raster/StandardValueRaster.cs
+++ b/T3/Gui/Windows/TimeLine/Raster/StandardValueRaster.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using T3.Core.Animation;
@@ -18,7 +18,7 @@ namespace T3.Gui.Windows.TimeLine
             var unitInSecs = UnitsPerSecond * playback.Bpm / 240f * 4;
 
             var scale = TimeLineCanvas.Current.NestedTimeScale / unitInSecs;
-            var scroll = TimeLineCanvas.Current.NestedTimeOffset;
+            var scroll = TimeLineCanvas.Current.NestedTimeScroll;
             DrawTimeTicks(scale, scroll / scale, TimeLineCanvas.Current);
         }
 

--- a/T3/Gui/Windows/TimeLine/Raster/StandardValueRaster.cs
+++ b/T3/Gui/Windows/TimeLine/Raster/StandardValueRaster.cs
@@ -15,11 +15,11 @@ namespace T3.Gui.Windows.TimeLine
     {
         public override void Draw(Playback playback)
         {
-            var unitInSecs = UnitsPerSecond * playback.Bpm / 240f * 4;
+            var unitInSecs = UnitsPerSecond / playback.Bpm * 60f * 4f;
 
-            var scale = TimeLineCanvas.Current.NestedTimeScale / unitInSecs;
-            var scroll = TimeLineCanvas.Current.NestedTimeScroll;
-            DrawTimeTicks(scale, scroll / scale, TimeLineCanvas.Current);
+            var scale = TimeLineCanvas.Current.Scale.X / unitInSecs;
+            var scroll = TimeLineCanvas.Current.Scroll.X * unitInSecs;
+            DrawTimeTicks(scale, scroll, TimeLineCanvas.Current);
         }
 
         /// <summary>

--- a/T3/Gui/Windows/TimeLine/TimeLineCanvas.cs
+++ b/T3/Gui/Windows/TimeLine/TimeLineCanvas.cs
@@ -302,7 +302,7 @@ namespace T3.Gui.Windows.TimeLine
             {
                 if (!IsCurrentTimeVisible())
                 {
-                    // assume we are not scrolling, what screen positino would the playhead be at?
+                    // assume we are not scrolling, what screen position would the playhead be at?
                     var oldScroll = Scroll;
                     Scroll = new Vector2(0, Scroll.Y);
                     var posScreen = TransformX((float) Playback.TimeInBars);

--- a/T3/Gui/Windows/TimeLine/TimeLineImage.cs
+++ b/T3/Gui/Windows/TimeLine/TimeLineImage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Numerics;
 using Core.Audio;
@@ -31,8 +31,8 @@ namespace T3.Gui.Windows.TimeLine
             //                        contentRegionMax + windowPos, new Color(0,0,0,0.3f));
             
             var songDurationInBars = (float)(soundTrack.LengthInSeconds * soundTrack.Bpm / 240);
-            var xMin= TimeLineCanvas.Current.TransformGlobalTime((float)soundTrack.StartTime);
-            var xMax = TimeLineCanvas.Current.TransformGlobalTime(songDurationInBars + (float)soundTrack.StartTime);
+            var xMin = TimeLineCanvas.Current.TransformX((float) soundTrack.StartTime);
+            var xMax = TimeLineCanvas.Current.TransformX(songDurationInBars + (float)soundTrack.StartTime);
             
             var resourceManager = ResourceManager.Instance();
             if (resourceManager.Resources.TryGetValue(_srvResId, out var resource2) && resource2 is ShaderResourceViewResource srvResource)

--- a/T3/Gui/Windows/TimeLine/TimeSelectionRange.cs
+++ b/T3/Gui/Windows/TimeLine/TimeSelectionRange.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
@@ -29,7 +29,6 @@ namespace T3.Gui.Windows.TimeLine
             _selectionTimeRange = _timeLineCanvas.GetSelectionTimeRange();
             if (!_selectionTimeRange.IsValid || _selectionTimeRange.Duration <= 0)
                 return;
-
 
             var contentRegionMin = ImGui.GetWindowContentRegionMin() + ImGui.GetWindowPos();
             var contentRegionMax = ImGui.GetWindowContentRegionMax() + ImGui.GetWindowPos();

--- a/T3/Gui/Windows/TimeLine/TimelineCurveEditArea.cs
+++ b/T3/Gui/Windows/TimeLine/TimelineCurveEditArea.cs
@@ -211,7 +211,8 @@ namespace T3.Gui.Windows.TimeLine
             {
                 var sampledValue = (float)curve.GetSampledValue(hoverTime);
                 var posOnCanvas = new Vector2(hoverTime, sampledValue);
-                var posOnScreen = TimeLineCanvas.TransformPosition(posOnCanvas) - new Vector2(KeyframeIconWidth / 2 + 1, KeyframeIconWidth / 2 + 1);
+                var posOnScreen = TimeLineCanvas.TransformPosition(posOnCanvas)
+                                - new Vector2(KeyframeIconWidth / 2 + 1, KeyframeIconWidth / 2 + 1);
                 Icons.Draw(Icon.CurveKeyframe, posOnScreen);
             }
 
@@ -267,7 +268,6 @@ namespace T3.Gui.Windows.TimeLine
             
             if (!ImGui.IsItemActive() || !ImGui.IsMouseDragging(0, 0f))
                 return;
-
 
             if (ImGui.GetIO().KeyCtrl && _changeKeyframesCommand == null)
             {

--- a/T3/Gui/Windows/TimeLine/TimelineCurveEditArea.cs
+++ b/T3/Gui/Windows/TimeLine/TimelineCurveEditArea.cs
@@ -421,7 +421,7 @@ namespace T3.Gui.Windows.TimeLine
         #region  implement snapping -------------------------
         SnapResult IValueSnapAttractor.CheckForSnap(double targetTime, float canvasScale)
         {
-            _snapThresholdOnCanvas = SnapDistance / canvasScale;;
+            _snapThresholdOnCanvas = SnapDistance / canvasScale;
             var maxForce = 0.0;
             var bestSnapTime = Double.NaN;
 

--- a/T3/Gui/Windows/TimeLine/TimelineCurveEditArea.cs
+++ b/T3/Gui/Windows/TimeLine/TimelineCurveEditArea.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -306,7 +306,7 @@ namespace T3.Gui.Windows.TimeLine
                 }
             }
             
-            var newDragPosition = TimeLineCanvas.Current.InverseTransformPosition(ImGui.GetIO().MousePos);
+            var newDragPosition = TimeLineCanvas.Current.InverseTransformPositionFloat(ImGui.GetIO().MousePos);
 
             var allowHorizontal = CurveInputEditing.MoveDirection == CurveInputEditing.MoveDirections.Both
                                    || CurveInputEditing.MoveDirection == CurveInputEditing.MoveDirections.Horizontal
@@ -463,7 +463,7 @@ namespace T3.Gui.Windows.TimeLine
             var width = ImGui.GetWindowWidth();
 
             double dU = canvas.InverseTransformDirection(new Vector2(step, 0)).X;
-            double u = canvas.InverseTransformPosition(canvas.WindowPos).X;
+            double u = canvas.InverseTransformPositionFloat(canvas.WindowPos).X;
             var x = canvas.WindowPos.X;
 
             var steps = (int)(width / step);

--- a/T3/Gui/Windows/Variations/VariationThumbnail.cs
+++ b/T3/Gui/Windows/Variations/VariationThumbnail.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -253,7 +253,7 @@ namespace T3.Gui.Windows.Variations
             }
 
             var newDragPos = ImGui.GetMousePos() - _dragStartDelta;
-            var newDragPosInCanvas = _canvas.InverseTransformPosition(newDragPos);
+            var newDragPosInCanvas = _canvas.InverseTransformPositionFloat(newDragPos);
 
             // Implement snapping to others
             var bestDistanceInCanvas = float.PositiveInfinity;


### PR DESCRIPTION
Removed nested time handling completely - now, global scaling and scrolling get adjusted as you jump in or out of a timeline.
Also renamed InverseTransformPosition to InverseTransformPositionFloat for clarity.
Changed some scaling to float (TransformPositionFloat) instead of integer (TransformPosition).
Was it intended to have so many transformations running with integer coordinates? Should we cross-check the use?
You should now only need to override TransformPositionFloat and InverseTransformPositionFloat to get a functioning subclass.
Snapping works better now but snapping while pressing alt needs to be looked at.
Known bugs: The UI does not render correctly when rendering the timeline backwards (negative scale).

In addition: hovering over the output camera allows you to zoom in/out by using the center mouse wheel. No need to activate the window anymore.