### PR TITLE
Video output with LoopRange, Bars and Frames

### DIFF
--- a/Core/Animation/Playback.cs
+++ b/Core/Animation/Playback.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace T3.Core.Animation
@@ -93,12 +93,12 @@ namespace T3.Core.Animation
 
         public double BarsFromSeconds(double secs)
         {
-            return secs * Bpm / 240f;
+            return secs * Bpm / 240.0;
         }
         
         public double SecondsFromBars(double bars)
         {
-            return bars * 240 / Bpm;
+            return bars * 240.0 / Bpm;
         }
         
         private static double _lastFrameStart;

--- a/T3/Gui/Styling/CustomComponents.cs
+++ b/T3/Gui/Styling/CustomComponents.cs
@@ -562,7 +562,9 @@ namespace T3.Gui
             }
 
             ImGui.SetNextItemWidth(size.X);
-            var modified = ImGui.Combo("##dropDown", ref index, valueNames, valueNames.Length);
+            // FIXME: using only "##dropdown" did not allow for multiple combos (see for example renderSequenceWindow.cs)
+            // so we add the type and label here - but this is only a temporary hack...
+            var modified = ImGui.Combo($"##dropDown{enumType}{label}", ref index, valueNames, valueNames.Length, valueNames.Length);
             return modified;
         }
     }

--- a/T3/Gui/Windows/RenderHelperWindow.cs
+++ b/T3/Gui/Windows/RenderHelperWindow.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows.Forms;
+using ImGuiNET;
+using T3.Core;
+using T3.Core.Animation;
+using T3.Core.Logging;
+
+namespace T3.Gui.Windows
+{
+    public abstract class RenderHelperWindow : Window
+    {
+        public enum TimeReference
+        {
+            Bars,
+            Seconds,
+            Frames
+        }
+
+        protected void DrawTimeSetup()
+        {
+            // use our loop range instead of entered values?
+            ImGui.Checkbox("Use Loop Range", ref _useLoopRange);
+            if (_useLoopRange) UseLoopRange();
+
+            // convert times if reference time selection changed
+            int newTimeReferenceIndex = (int)_timeReference;
+            if (CustomComponents.DrawEnumSelector<TimeReference>(ref newTimeReferenceIndex, "Time reference"))
+            {
+                TimeReference newTimeReference = (TimeReference)newTimeReferenceIndex;
+                _startTime = (float)ConvertReferenceTime(_startTime, _timeReference, newTimeReference);
+                _endTime = (float)ConvertReferenceTime(_endTime, _timeReference, newTimeReference);
+                _timeReference = newTimeReference;
+            }
+
+            CustomComponents.FloatValueEdit($"Start in {_timeReference}", ref _startTime);
+            CustomComponents.FloatValueEdit($"End in {_timeReference}", ref _endTime);
+
+            // change FPS if required
+            CustomComponents.FloatValueEdit("FPS", ref _fps, 0);
+            if (_fps < 0) _fps = -_fps;
+            if (_fps != 0)
+            {
+                _startTime = (float)ConvertFPS(_startTime, _lastValidFps, _fps);
+                _endTime = (float)ConvertFPS(_endTime, _lastValidFps, _fps);
+                _lastValidFps = _fps;
+            }
+
+            double startTimeInSeconds = ReferenceTimeToSeconds(_startTime, _timeReference);
+            double endTimeInSeconds = ReferenceTimeToSeconds(_endTime, _timeReference);
+            _frameCount = (int)Math.Round((endTimeInSeconds - startTimeInSeconds) * _fps);
+        }
+
+        protected static bool ValidateOrCreateTargetFolder(string targetFile)
+        {
+            string directory = Path.GetDirectoryName(targetFile);
+            if (targetFile != directory && File.Exists(targetFile))
+            {
+                const MessageBoxButtons buttons = MessageBoxButtons.YesNo;
+
+                // FIXME: get a nicer popup window here...
+                var result = MessageBox.Show("File exists. Overwrite?", "Render Video", buttons);
+                return (result == DialogResult.Yes);
+            }
+
+            if (!Directory.Exists(directory))
+            {
+                try
+                {
+                    Directory.CreateDirectory(directory);
+                }
+                catch (Exception e)
+                {
+                    Log.Warning($"Failed to create target folder '{directory}': {e.Message}");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public static void UseLoopRange()
+        {
+            var playback = Playback.Current; // TODO, this should be non-static eventually
+            var startInSeconds = playback.SecondsFromBars(playback.LoopRange.Start);
+            var endInSeconds = playback.SecondsFromBars(playback.LoopRange.End);
+            _startTime = (float)SecondsToReferenceTime(startInSeconds, _timeReference);
+            _endTime = (float)SecondsToReferenceTime(endInSeconds, _timeReference);
+        }
+
+        public static double ConvertReferenceTime(double time,
+            TimeReference oldTimeReference,
+            TimeReference newTimeReference)
+        {
+            // only convert time value if time reference changed
+            if (oldTimeReference == newTimeReference) return time;
+
+            var seconds = ReferenceTimeToSeconds(time, oldTimeReference);
+            return SecondsToReferenceTime(seconds, newTimeReference);
+        }
+
+        protected static double ConvertFPS(double time, double oldFps, double newFps)
+        {
+            // only convert FPS if values are valid
+            if (oldFps == 0 || newFps == 0) return time;
+
+            return time / oldFps * newFps;
+        }
+
+        protected static double ReferenceTimeToSeconds(double time, TimeReference timeReference)
+        {
+            var playback = Playback.Current; // TODO, this should be non-static eventually
+            switch (timeReference)
+            {
+                case TimeReference.Bars:
+                    return playback.SecondsFromBars(time);
+                case TimeReference.Seconds:
+                    return time;
+                case TimeReference.Frames:
+                    if (_fps != 0)
+                        return time / _fps;
+                    else
+                        return time / 60.0;
+            }
+
+            // this is an error, don't change the value
+            return time;
+        }
+
+        protected static double SecondsToReferenceTime(double timeInSeconds, TimeReference timeReference)
+        {
+            var playback = Playback.Current; // TODO, this should be non-static eventually
+            switch (timeReference)
+            {
+                case TimeReference.Bars:
+                    return playback.BarsFromSeconds(timeInSeconds);
+                case TimeReference.Seconds:
+                    return timeInSeconds;
+                case TimeReference.Frames:
+                    if (_fps != 0)
+                        return timeInSeconds * _fps;
+                    else
+                        return timeInSeconds * 60.0;
+            }
+
+            // this is an error, don't change the value
+            return timeInSeconds;
+        }
+
+        protected static void SetPlaybackTimeForNextFrame()
+        {
+            double startTimeInSeconds = ReferenceTimeToSeconds(_startTime, _timeReference);
+            double endTimeInSeconds = ReferenceTimeToSeconds(_endTime, _timeReference);
+            Playback.Current.TimeInSecs = MathUtils.Lerp(startTimeInSeconds, endTimeInSeconds, Progress);
+        }
+
+        public override List<Window> GetInstances()
+        {
+            return new List<Window>();
+        }
+
+        protected static float Progress => (float)((double)_frameIndex / (double)_frameCount).Clamp(0, 1);
+
+        protected static bool _useLoopRange;
+        protected static TimeReference _timeReference;
+        protected static float _startTime;
+        protected static float _endTime = 1.0f; // one Bar
+        protected static float _fps = 60.0f;
+        protected static float _lastValidFps = _fps;
+
+        protected static int _frameIndex;
+        protected static int _frameCount;
+    }
+}

--- a/T3/Gui/Windows/RenderSequenceWindow.cs
+++ b/T3/Gui/Windows/RenderSequenceWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using ImGuiNET;
@@ -7,17 +7,19 @@ using T3.Core;
 using T3.Core.Animation;
 using T3.Core.Logging;
 using T3.Gui.UiHelpers;
+using T3.Gui.Windows;
 using T3.Gui.Windows.Output;
 using Vector2 = System.Numerics.Vector2;
 
 namespace T3.Gui.Windows
 {
-    public class RenderSequenceWindow : Window
+    public class RenderSequenceWindow : RenderHelperWindow
     {
         public RenderSequenceWindow()
         {
             Config.Title = "Render Sequence";
             Config.Size = new Vector2(350, 300);
+            _lastHelpString = "Hint: Use a [RenderTarget] with format R8G8B8A8_UNorm for faster exports.";
         }
 
         protected override void UpdateBeforeDraw()
@@ -27,131 +29,118 @@ namespace T3.Gui.Windows
 
         protected override void DrawContent()
         {
-            //ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, 10);
-            CustomComponents.FloatValueEdit("Start in secs", ref _startTime);
-            CustomComponents.FloatValueEdit("End in secs", ref _endTime);
-            CustomComponents.FloatValueEdit("FPS", ref _fps);
+            // ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, 10);
+            DrawTimeSetup();
 
-            CustomComponents.StringValueEdit("Folder", ref _targetFolder);
-            ImGui.SameLine();
-            FileOperations.DrawFileSelector(FileOperations.FilePickerTypes.Folder, ref _targetFolder);
-
+            // custom parameters for this renderer
             var intFileFormat = (int)_fileFormat;
             if (CustomComponents.DrawEnumSelector<ScreenshotWriter.FileFormats>(ref intFileFormat, "FileFormat"))
             {
                 _fileFormat = (ScreenshotWriter.FileFormats)intFileFormat;
             }
-
-            _frameCount = (int)((_endTime - _startTime) * _fps) + 1;
-            CustomComponents.HelpText($"That's {_frameCount} frames");
-
+            CustomComponents.StringValueEdit("Folder", ref _targetFolder);
+            ImGui.SameLine();
+            FileOperations.DrawFileSelector(FileOperations.FilePickerTypes.Folder, ref _targetFolder);
             ImGui.Separator();
 
             var mainTexture = OutputWindow.GetPrimaryOutputWindow()?.GetCurrentTexture();
+            if (mainTexture == null)
+            {
+                CustomComponents.HelpText("You have selected an operator that does not render. " +
+                                          "Hint: Use a [RenderTarget] with format R8G8B8A8_UNorm fast exports.");
+                return;
+            }
+
             if (!_isExporting)
             {
                 if (ImGui.Button("Start Export"))
                 {
-                    if (ValidateOrCreateTargetFolder())
+                    if (ValidateOrCreateTargetFolder(_targetFolder))
                     {
                         _isExporting = true;
                         _exportStartedTime = Playback.RunTimeInSecs;
                         _frameIndex = 0;
                         SetPlaybackTimeForNextFrame();
-                        
-                        SaveImage(mainTexture);
+
+                        SaveCurrentFrameAndAdvance(mainTexture);
                     }
                 }
-                ImGui.SameLine();
-                ImGui.AlignTextToFramePadding();
-                CustomComponents.HelpText("   Hint: Use a [RenderTarget] with format R8G8B8A8_UNorm faster exports.");
             }
             else
             {
                 var success = SaveCurrentFrameAndAdvance(mainTexture);
                 ImGui.ProgressBar(Progress, new Vector2(-1, 4));
 
-                if (_frameIndex > _frameCount || !success)
+                var currentTime = Playback.RunTimeInSecs;
+                var durationSoFar = currentTime - _exportStartedTime;
+                if (GetRealFrame() >= _frameCount || !success)
                 {
+                    var successful = success ? "successfully" : "unsuccessfully";
+                    _lastHelpString = $"Sequence export finished {successful} in {durationSoFar:0.00}s";
+                    _isExporting = false;
+                }
+                else if (ImGui.Button("Cancel"))
+                {
+                    _lastHelpString = $"Sequence export cancelled after {durationSoFar:0.00}s";
                     _isExporting = false;
                 }
                 else
                 {
-                    if (ImGui.Button("Cancel"))
-                    {
-                        _isExporting = false;
-                    }
+                    var estimatedTimeLeft = durationSoFar * (1 - Progress);
+                    _lastHelpString = $"Saved {ScreenshotWriter.LastFilename} frame {GetRealFrame()+1}/{_frameCount}  ";
+                    _lastHelpString += $"{Progress * 100.0:0}%  {estimatedTimeLeft:0}s left";
                 }
 
-                var currentTime = Playback.RunTimeInSecs;
-                var durationSoFar = currentTime - _exportStartedTime;
-                var estimatedTimeLeft = durationSoFar * (1 - Progress);
-                CustomComponents.HelpText($"Saved {ScreenshotWriter.LastFilename}  {Progress * 100.0:0}%  {estimatedTimeLeft:0}s left");
+                if (!_isExporting)
+                {
+                    ScreenshotWriter.Dispose();
+                }
             }
+
+            CustomComponents.HelpText(_lastHelpString);
         }
 
-
+        private static int GetRealFrame()
+        {
+            // since we are double-buffering and discarding the first few frames,
+            // we have to subtract these frames to get the currently really shown framenumber...
+            return _frameIndex - ScreenshotWriter.SkipImages;
+        }
 
         private static string GetFilePath()
         {
-            return Path.Combine(_targetFolder, $"output_{_frameIndex:0000}.{Extension}");
+            return Path.Combine(_targetFolder, $"output_{GetRealFrame():0000}.{Extension}");
         }
 
-        private static bool ValidateOrCreateTargetFolder()
-        {
-            if (!Directory.Exists(_targetFolder))
-            {
-                try
-                {
-                    Directory.CreateDirectory(_targetFolder);
-                }
-                catch (Exception e)
-                {
-                    Log.Warning($"Failed to create target folder '{_targetFolder}': {e.Message}");
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        
         private static bool SaveCurrentFrameAndAdvance(Texture2D mainTexture)
         {
-            var success = SaveImage(mainTexture);
-            
-
-            _frameIndex++;
-            SetPlaybackTimeForNextFrame();
-            return success;
+            try
+            {
+                var success = SaveImage(mainTexture);
+                _frameIndex++;
+                SetPlaybackTimeForNextFrame();
+                return success;
+            }
+            catch (Exception e)
+            {
+                _lastHelpString = e.ToString();
+                _isExporting = false;
+                return false;
+            }
         }
-        
+
         private static bool SaveImage(Texture2D mainTexture)
         {
             return ScreenshotWriter.SaveBufferToFile(mainTexture, GetFilePath(), _fileFormat);
         }
 
-        private static void SetPlaybackTimeForNextFrame()
-        {
-            Playback.Current.TimeInSecs = MathUtils.Lerp(_startTime, _endTime, Progress);
-        }
-
-        public override List<Window> GetInstances()
-        {
-            return new List<Window>();
-        }
-
         private static string Extension => _fileFormat.ToString().ToLower(); 
-        private static float Progress => (float)(_frameIndex / (double)_frameCount).Clamp(0, 1);
 
         private static double _exportStartedTime;
         private static bool _isExporting;
-        private static float _startTime;
-        private static float _endTime = 1;
-        private static float _fps = 60;
-        private static int _frameIndex;
-        private static int _frameCount;
         private static string _targetFolder = "./Render";
 
         private static ScreenshotWriter.FileFormats _fileFormat;
+        private static string _lastHelpString = string.Empty;
     }
 }

--- a/T3/Gui/Windows/RenderVideoWindow.cs
+++ b/T3/Gui/Windows/RenderVideoWindow.cs
@@ -4,16 +4,16 @@ using System.IO;
 using System.Windows.Forms;
 using ImGuiNET;
 using SharpDX.Direct3D11;
-using T3.Core;
 using T3.Core.Animation;
 using T3.Core.Logging;
 using T3.Gui.UiHelpers;
 using T3.Gui.Windows.Output;
 using Vector2 = System.Numerics.Vector2;
+using Icon = T3.Gui.Styling.Icon;
 
 namespace T3.Gui.Windows
 {
-    public class RenderVideoWindow : Window
+    public class RenderVideoWindow : RenderHelperWindow
     {
         public RenderVideoWindow()
         {
@@ -24,36 +24,34 @@ namespace T3.Gui.Windows
 
         protected override void UpdateBeforeDraw()
         {
-            ImGui.SetNextWindowSize(new Vector2(550, 270));
+            ImGui.SetNextWindowSize(new Vector2(550, 300));
         }
 
         protected override void DrawContent()
         {
             //ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, 10);
-            CustomComponents.FloatValueEdit("Start in secs", ref _startTime);
-            CustomComponents.FloatValueEdit("End in secs", ref _endTime);
-            CustomComponents.FloatValueEdit("FPS", ref _fps);
-            CustomComponents.IntValueEdit("bitrate", ref _bitrate, 0, 25000000, 1000);
+            DrawTimeSetup();
+
+            // custom parameters for this renderer
+            CustomComponents.IntValueEdit("Bitrate", ref _bitrate, 0, 25000000, 1000);
             CustomComponents.StringValueEdit("File", ref _targetFile);
             ImGui.SameLine();
             FileOperations.DrawFileSelector(FileOperations.FilePickerTypes.File, ref _targetFile);
+            ImGui.Separator();
 
             var mainTexture = OutputWindow.GetPrimaryOutputWindow()?.GetCurrentTexture();
-            if (mainTexture == null) return;
-
-            var currentDesc = mainTexture.Description;
-            SharpDX.Size2 size;
-            size.Width = currentDesc.Width;
-            size.Height = currentDesc.Height;
-            _frameCount = (int)((_endTime - _startTime) * _fps) + 1;
-
-            ImGui.Separator();
+            if (mainTexture == null)
+            {
+                CustomComponents.HelpText("You have selected an operator that does not render. " +
+                                          "Hint: Use a [RenderTarget] with format R8G8B8A8_UNorm fast exports.");
+                return;
+            }
 
             if (!_isExporting)
             {
                 if (ImGui.Button("Start Export"))
                 {
-                    if (ValidateOrCreateTargetFolder())
+                    if (ValidateOrCreateTargetFolder(_targetFile))
                     {
                         _isExporting = true;
                         _exportStartedTime = Playback.RunTimeInSecs;
@@ -62,9 +60,14 @@ namespace T3.Gui.Windows
 
                         if (_videoWriter == null)
                         {
+                            var currentDesc = mainTexture.Description;
+                            SharpDX.Size2 size;
+                            size.Width = currentDesc.Width;
+                            size.Height = currentDesc.Height;
+
                             _videoWriter = new MP4VideoWriter(_targetFile, size);
                             _videoWriter.Bitrate = _bitrate;
-                            _videoWriter.Framerate = (int)(_fps + 0.5f);
+                            _videoWriter.Framerate = (int)_fps;
                         }
 
                         SaveCurrentFrameAndAdvance(ref mainTexture);
@@ -76,66 +79,48 @@ namespace T3.Gui.Windows
                 var success = SaveCurrentFrameAndAdvance(ref mainTexture);
                 ImGui.ProgressBar(Progress, new Vector2(-1, 4));
 
-                if (_frameIndex > _frameCount)
+                var currentTime = Playback.RunTimeInSecs;
+                var durationSoFar = currentTime - _exportStartedTime;
+                if (GetRealFrame() >= _frameCount || !success)
                 {
-                    var currentTime = Playback.RunTimeInSecs;
-                    var durationSoFar = currentTime - _exportStartedTime;
-                    _lastHelpString = $"Video export finished successfully in {durationSoFar:0.00}s";
-                }
-
-                if (_frameIndex > _frameCount || !success || ImGui.Button("Cancel"))
-                {
+                    var successful = success ? "successfully" : "unsuccessfully";
+                    _lastHelpString = $"Sequence export finished {successful} in {durationSoFar:0.00}s";
                     _isExporting = false;
-                    _videoWriter?.Dispose();
-                    _videoWriter = null;
+                }
+                else if (ImGui.Button("Cancel"))
+                {
+                    _lastHelpString = $"Sequence export cancelled after {durationSoFar:0.00}s";
+                    _isExporting = false;
                 }
                 else
                 {
-                    var currentTime = Playback.RunTimeInSecs;
-                    var durationSoFar = currentTime - _exportStartedTime;
                     var estimatedTimeLeft = durationSoFar * (1 - Progress);
-                    _lastHelpString = $"Saved {_videoWriter.FilePath} frame {_frameIndex}/{_frameCount}  ";
+                    _lastHelpString = $"Saved {_videoWriter.FilePath} frame {GetRealFrame()+1}/{_frameCount}  ";
                     _lastHelpString += $"{Progress * 100.0:0}%  {estimatedTimeLeft:0}s left";
+                }
+
+                if (!_isExporting)
+                {
+                    _videoWriter?.Dispose();
+                    _videoWriter = null;
                 }
             }
 
             CustomComponents.HelpText(_lastHelpString);
         }
 
-        private static bool ValidateOrCreateTargetFolder()
+        private static int GetRealFrame()
         {
-            string directory = Path.GetDirectoryName(_targetFile);
-            if (File.Exists(_targetFile))
-            {
-                const MessageBoxButtons buttons = MessageBoxButtons.YesNo;
-
-                // FIXME: get a nicer popup window here...
-                var result = MessageBox.Show("File exists. Overwrite?", "Render Video", buttons);
-                return (result == DialogResult.Yes);
-            }
-
-            if (!Directory.Exists(directory))
-            {
-                try
-                {
-                    Directory.CreateDirectory(directory);
-                }
-                catch (Exception e)
-                {
-                    Log.Warning($"Failed to create target folder '{directory}': {e.Message}");
-                    return false;
-                }
-            }
-            return true;
+            // since we are double-buffering and discarding the first few frames,
+            // we have to subtract these frames to get the currently really shown framenumber...
+            return _frameIndex - MediaFoundationVideoWriter.SkipImages;
         }
-
 
         private static bool SaveCurrentFrameAndAdvance(ref Texture2D mainTexture)
         {
             try
             {
                 _videoWriter.AddVideoFrame(ref mainTexture);
-
                 _frameIndex++;
                 SetPlaybackTimeForNextFrame();
             }
@@ -151,27 +136,9 @@ namespace T3.Gui.Windows
             return true;
         }
 
-        private static void SetPlaybackTimeForNextFrame()
-        {
-            Playback.Current.TimeInSecs = MathUtils.Lerp(_startTime, _endTime, Progress);
-        }
-
-        public override List<Window> GetInstances()
-        {
-            return new List<Window>();
-        }
-
-        // private static string Extension => _videoWriter.ToString().ToLower(); 
-        private static float Progress => (float)(_frameIndex / (double)_frameCount).Clamp(0, 1);
-
         private static double _exportStartedTime;
         private static bool _isExporting;
-        private static float _startTime;
-        private static float _endTime = 1.0f;
-        private static float _fps = 60.0f;
         private static int _bitrate = 15000000;
-        private static int _frameIndex;
-        private static int _frameCount;
         private static string _targetFile = "./Render/output.mp4";
 
         private static MP4VideoWriter _videoWriter = null;


### PR DESCRIPTION
I cleaned up the render sequence and render video output:

* You can now choose to use the LoopRange as render range
* You can select between Bars, Seconds and Frames as time reference
* I cleaned up the buffering to get frames at precise times (incoming textures are normally *two* frames behind)
* The new class RenderHelperWindow is used to group GUI and values that are used both for sequence and video output
* Changing settings for the sequence output will change settings for the video output and vice versa
* Some more bug fixes

I tested frame skipping/shifting with an NVIDIA card. It would be interesting to know if it works on AMD graphics cards in exactly the same way.

* *Known bug:* Using two enum dropdown boxes proved to be impossible. They would show wrong or no entries. I now used a temporary fix in T3/Gui/Styling/CustomComponents.cs to be able to present the PNG/JPG selection option in T3/Gui/Windows/RenderSequenceWindow.cs, but it's a hack and should be replaced by a proper solution, for example with instance numbering.
* *Known Bug:* Disabling double-buffering in the driver may cause the renderings to be off by one or two frames again
* *Known Bug:* MP4 video output still does not allow non-integer fps