### PR TITLE
Dragging a child node no longer affects parent

### DIFF
--- a/T3/Gui/Graph/GraphNode.cs
+++ b/T3/Gui/Graph/GraphNode.cs
@@ -35,6 +35,12 @@ namespace T3.Gui.Graph
     {
         public static void Draw(SymbolChildUi childUi, Instance instance)
         {
+            if (_instanceToSwitchGraphWindowTo != null)
+            {
+                GraphCanvas.Current.SetCompositionToChildInstance(_instanceToSwitchGraphWindowTo);
+                _instanceToSwitchGraphWindowTo = null;
+            }
+
             if (instance == null)
                 return;
 
@@ -223,10 +229,6 @@ namespace T3.Gui.Graph
 
                     
 
-                    
-                    // A horrible work around to prevent exception because CompositionOp changed during drawing.
-                    // A better solution would defer setting the compositionOp to the beginning of next frame.
-                    var justOpenedChild = false;
                     if (hovered && ImGui.IsMouseDoubleClicked(0) 
                                 && !RenameInstanceOverlay.IsOpen
                                 && (customUiResult & SymbolChildUi.CustomUiResult.PreventOpenSubGraph) == 0)
@@ -247,9 +249,8 @@ namespace T3.Gui.Graph
 
                             if (!blocked)
                             {
-                                GraphCanvas.Current.SetCompositionToChildInstance(instance);
+                                _instanceToSwitchGraphWindowTo = instance;
                                 ImGui.CloseCurrentPopup();
-                                justOpenedChild = true;
                             }
                         }
                     }
@@ -266,7 +267,6 @@ namespace T3.Gui.Graph
                                                    && ImGui.GetMouseDragDelta(ImGuiMouseButton.Middle, 0).Length() < UserSettings.Config.ClickThreshold;
 
                     if ((activatedWithLeftMouse || activatedWithMiddleMouse)
-                        && !justOpenedChild
                         && string.IsNullOrEmpty(T3Ui.OpenedPopUpName)
                         && (customUiResult & SymbolChildUi.CustomUiResult.PreventOpenParameterPopUp) == 0)
                     {
@@ -275,7 +275,7 @@ namespace T3.Gui.Graph
                     }
 
                     ImGui.SetNextWindowSizeConstraints(new Vector2(280, 40), new Vector2(280, 320));
-                    if (!justOpenedChild && ImGui.BeginPopup("parameterContextPopup"))
+                    if (ImGui.BeginPopup("parameterContextPopup"))
                     {
                         ImGui.PushFont(Fonts.FontSmall);
                         var compositionSymbolUi = SymbolUiRegistry.Entries[GraphCanvas.Current.CompositionOp.Symbol.Id];
@@ -1273,5 +1273,6 @@ namespace T3.Gui.Graph
         private static ImRect _selectableScreenRect;
         private static ImDrawListPtr _drawList;
         private static bool _isVisible;
+        private static Instance _instanceToSwitchGraphWindowTo;
     }
 }

--- a/T3/Gui/Graph/Interaction/NodeSelection.cs
+++ b/T3/Gui/Graph/Interaction/NodeSelection.cs
@@ -211,7 +211,10 @@ namespace T3.Gui.Graph.Interaction
         public static void DeselectCompositionChild(Instance compositionOp, Guid symbolChildId)
         {
             if (!NodeOperations.TryGetUiAndInstanceInComposition(symbolChildId, compositionOp, out var childUi, out var instance))
+            {
+                Log.Debug($"{nameof(NodeSelection)}: Could not find Ui and Instance in {compositionOp.GetType()}: {symbolChildId}");
                 return;
+            }
 
             Selection.Remove(childUi);
             if (instance is ITransformable transformable)

--- a/T3/Gui/Graph/Interaction/SelectableNodeMovement.cs
+++ b/T3/Gui/Graph/Interaction/SelectableNodeMovement.cs
@@ -25,6 +25,15 @@ namespace T3.Gui.Graph.Interaction
         /// </summary>
         public static void Handle(ISelectableCanvasObject node, Instance instance = null)
         {
+            var currentCompositionOp = GraphCanvas.Current.CompositionOp;
+            var compositionChanged = currentCompositionOp != _currentCompositionOp;
+
+            if (compositionChanged)
+            {
+                ClearDraggedNodes();
+                _currentCompositionOp = currentCompositionOp;
+            }
+
             if (ImGui.IsItemActive())
             {
                 if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
@@ -66,8 +75,7 @@ namespace T3.Gui.Graph.Interaction
                     return;
 
                 var singleDraggedNode = (_draggedNodes.Count == 1) ? _draggedNodes[0] : null;
-                _draggedNodeId = Guid.Empty;
-                _draggedNodes.Clear();
+                ClearDraggedNodes();
 
                 var wasDragging = ImGui.GetMouseDragDelta(ImGuiMouseButton.Left).LengthSquared() > UserSettings.Config.ClickThreshold;
                 if (wasDragging)
@@ -151,6 +159,12 @@ namespace T3.Gui.Graph.Interaction
                     NodeSelection.SetSelection(node);
                 }
             }
+        }
+
+        private static void ClearDraggedNodes()
+        {
+            _draggedNodeId = Guid.Empty;
+            _draggedNodes.Clear();
         }
 
         private static void DisconnectDraggedNodes()
@@ -509,6 +523,7 @@ namespace T3.Gui.Graph.Interaction
 
         private static Guid _draggedNodeId = Guid.Empty;
         private static List<ISelectableCanvasObject> _draggedNodes = new();
+        private static Instance _currentCompositionOp;
 
         private static class ShakeDetector
         {

--- a/T3/Gui/Graph/Interaction/SelectableNodeMovement.cs
+++ b/T3/Gui/Graph/Interaction/SelectableNodeMovement.cs
@@ -38,7 +38,7 @@ namespace T3.Gui.Graph.Interaction
             {
                 if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
                 {
-                    var compositionSymbolId = GraphCanvas.Current.CompositionOp.Symbol.Id;
+                    var compositionSymbolId = currentCompositionOp.Symbol.Id;
                     _draggedNodeId = node.Id;
                     if (node.IsSelected)
                     {
@@ -46,7 +46,7 @@ namespace T3.Gui.Graph.Interaction
                     }
                     else
                     {
-                        var parentUi = SymbolUiRegistry.Entries[GraphCanvas.Current.CompositionOp.Symbol.Id];
+                        var parentUi = SymbolUiRegistry.Entries[currentCompositionOp.Symbol.Id];
                         if(UserSettings.Config.SmartGroupDragging)
                             _draggedNodes = FindSnappedNeighbours(parentUi, node).ToList();
                         
@@ -85,7 +85,7 @@ namespace T3.Gui.Graph.Interaction
 
                     if (singleDraggedNode != null && ConnectionMaker.ConnectionSplitHelper.BestMatchLastFrame != null && singleDraggedNode is SymbolChildUi childUi)
                     {
-                        var instanceForSymbolChildUi = GraphCanvas.Current.CompositionOp.Children.SingleOrDefault(child => child.SymbolChildId == childUi.Id);
+                        var instanceForSymbolChildUi = currentCompositionOp.Children.SingleOrDefault(child => child.SymbolChildId == childUi.Id);
                         ConnectionMaker.SplitConnectionWithDraggedNode(childUi, 
                                                                        ConnectionMaker.ConnectionSplitHelper.BestMatchLastFrame.Connection, 
                                                                        instanceForSymbolChildUi);
@@ -95,7 +95,7 @@ namespace T3.Gui.Graph.Interaction
                     var selectedInputs = NodeSelection.GetSelectedNodes<IInputUi>().ToList();
                     if (selectedInputs.Count > 0)
                     {
-                        var composition = GraphCanvas.Current.CompositionOp;
+                        var composition = currentCompositionOp;
                         var compositionUi = SymbolUiRegistry.Entries[composition.Symbol.Id];
                         composition.Symbol.InputDefinitions.Sort((a, b) =>
                                                                  {


### PR DESCRIPTION
fix for #162 plus some housekeeping

[a little housekeeping](https://github.com/still-scene/t3/commit/0b3a396ea0542b96ea87e6a31968ff920815528a) turned a // TODO into a // TODID. I probs shouldve branched separately but i guess i felt lazy