### PR TITLE
Improved settings UI take two, SymbolBrowser improvements

### DIFF
--- a/Core/Resource/MathUtils.cs
+++ b/Core/Resource/MathUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using System.Reflection;
 using T3.Core.Animation;
 using T3.Core.Operator;
 
@@ -144,6 +145,28 @@ namespace T3.Core
             }
 
             return v;
+        }
+
+        /// <summary>
+        /// A simple method to get a new index by "jumping" from a startIndex
+        /// When the jump would make the index exceed the valid range of the collection,
+        /// it will return an index that "wraps" around the other side
+        /// </summary>
+        /// <param name="startIndex">Index to jump from</param>
+        /// <param name="jumpAmount">How far to jump (usually 1 or -1 for forward and backward respectively)</param>
+        /// <param name="collection">The collection whose Count (Length for arrays) will be referenced</param>
+        /// <param name="realWrap">If false, this will default to making every wrap result in the first or last index of the collection.
+        /// If true, it will be a "real" wrap, where if you jump in excess of X, you will wrap to the index X distance from the other side. </param>
+        /// <returns></returns>
+        public static int WrapIndex(int startIndex, int jumpAmount, System.Collections.IList collection, bool realWrap = false)
+        {
+            int index = startIndex + jumpAmount;
+            index %= collection.Count;
+
+            bool newIndexIsNegative = index < 0;
+            int negativeWrapIndex = realWrap ? collection.Count + index : collection.Count - 1;
+
+            return newIndexIsNegative ? negativeWrapIndex : index;
         }
 
         public static Vector2 Min(Vector2 lhs, Vector2 rhs)

--- a/T3/Gui/Graph/Interaction/SymbolBrowser.cs
+++ b/T3/Gui/Graph/Interaction/SymbolBrowser.cs
@@ -90,8 +90,7 @@ namespace T3.Gui.Graph.Interaction
 
                 if (highlightedSymbolUi != null)
                 {
-                    ImGui.SetCursorPos(posInWindow + new Vector2(250, _size.Y + 1));
-                    DrawDescriptionPanel(highlightedSymbolUi, new Vector2(250, _resultListSize.Y));
+                    DrawDescriptionPanelLeftOrRight(posInWindow, highlightedSymbolUi);
                 }
 
                 ImGui.PopStyleVar(2);
@@ -304,6 +303,23 @@ namespace T3.Gui.Graph.Interaction
             highlightedSymbolUi = itemForHelp;
         }
 
+
+        private void DrawDescriptionPanelLeftOrRight(Vector2 posInWindow, SymbolUi highlightedSymbolUi)
+        {
+            float width = _resultListSize.X;
+            bool shouldShiftToRight = posInWindow.X + width > GraphCanvas.Current.WindowSize.X;
+            float xPositionOffset = shouldShiftToRight ? -width : width;
+            float xPosition = posInWindow.X + xPositionOffset;
+
+            Vector2 position = new Vector2(xPosition, posInWindow.Y + _size.Y + 1);
+
+            if (xPosition > 0)
+            {
+                ImGui.SetCursorPos(position);
+                DrawDescriptionPanel(highlightedSymbolUi, _resultListSize);
+            }
+        }
+
         private void DrawDescriptionPanel(SymbolUi itemForHelp, Vector2 size)
         {
             if (itemForHelp == null)
@@ -317,8 +333,8 @@ namespace T3.Gui.Graph.Interaction
                 return;
             
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, Vector2.One); // Padding between panels
-            
-            if (ImGui.BeginChildFrame(998, size))
+
+            if (ImGui.BeginChildFrame(998, size, ImGuiWindowFlags.ChildWindow))
             {
                 if (!string.IsNullOrEmpty(itemForHelp.Description))
                 {

--- a/T3/Gui/Graph/Interaction/SymbolBrowser.cs
+++ b/T3/Gui/Graph/Interaction/SymbolBrowser.cs
@@ -52,7 +52,7 @@ namespace T3.Gui.Graph.Interaction
         {
             if (!IsOpen)
             {
-                if (!ImGui.IsWindowFocused() || !ImGui.IsKeyReleased((ImGuiKey)Key.Tab))
+                if (!ImGui.IsWindowFocused() || !ImGui.IsKeyReleased((ImGuiKey)Key.Tab) || !ImGui.IsWindowHovered())
                     return;
 
                 if (NodeSelection.GetSelectedChildUis().Count() != 1)

--- a/T3/Gui/Graph/Interaction/SymbolBrowser.cs
+++ b/T3/Gui/Graph/Interaction/SymbolBrowser.cs
@@ -55,17 +55,16 @@ namespace T3.Gui.Graph.Interaction
                 if (!ImGui.IsWindowFocused() || !ImGui.IsKeyReleased((ImGuiKey)Key.Tab))
                     return;
 
-                if (NodeSelection.GetSelectedChildUis().Count() == 1)
-                {
-                    var childUi = NodeSelection.GetSelectedChildUis().ToList()[0];
-                    {
-                        var instance = NodeSelection.GetInstanceForSymbolChildUi(childUi);
-                        ConnectionMaker.OpenBrowserWithSingleSelection(this, childUi, instance);
-                    }
-                }
-                else
+                if (NodeSelection.GetSelectedChildUis().Count() != 1)
                 {
                     OpenAt(GraphCanvas.Current.InverseTransformPositionFloat(ImGui.GetIO().MousePos + new Vector2(-4, -20)), null, null, false, null);
+                    return;
+                }
+                
+                var childUi = NodeSelection.GetSelectedChildUis().ToList()[0];
+                {
+                    var instance = NodeSelection.GetInstanceForSymbolChildUi(childUi);
+                    ConnectionMaker.OpenBrowserWithSingleSelection(this, childUi, instance);
                 }
 
                 return;
@@ -77,7 +76,7 @@ namespace T3.Gui.Graph.Interaction
 
             ImGui.PushID(UiId);
             {
-                Vector2 posInWindow = GraphCanvas.Current.ChildPosFromCanvas(PosOnCanvas);
+                var posInWindow = GraphCanvas.Current.ChildPosFromCanvas(PosOnCanvas);
                 _posInScreen = GraphCanvas.Current.TransformPosition(PosOnCanvas);
                 _drawList = ImGui.GetWindowDrawList();
 
@@ -145,7 +144,7 @@ namespace T3.Gui.Graph.Interaction
             }
 
             var clickedOutside = ImGui.IsMouseClicked(ImGuiMouseButton.Left) && ImGui.IsWindowHovered();
-            bool shouldCancelConnectionMaker = clickedOutside
+            var shouldCancelConnectionMaker = clickedOutside
                 || ImGui.IsMouseClicked(ImGuiMouseButton.Right)
                 || ImGui.IsKeyDown((ImGuiKey)Key.Esc);
 

--- a/T3/Gui/SettingsUi.cs
+++ b/T3/Gui/SettingsUi.cs
@@ -1,0 +1,64 @@
+using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using T3.Gui.Windows;
+
+namespace t3.Gui
+{
+    public static class SettingsUi
+    {
+        /// <summary>
+        /// Draws a table of <see cref="UIControlledSetting"/>s
+        /// </summary>
+        /// <param name="tableID">Unique identifier for your table - will not be displayed</param>
+        /// <param name="settings">Settings to display</param>
+        /// <returns>Returns true if a setting has been modified</returns>
+        public static bool DrawSettingsTable(string tableID, UIControlledSetting[] settings)
+        {
+            ImGui.NewLine();
+            bool changed = false;
+            if (ImGui.BeginTable(tableID, 2, ImGuiTableFlags.BordersInnerH | ImGuiTableFlags.SizingFixedSame | ImGuiTableFlags.PadOuterX))
+            {
+                foreach (UIControlledSetting setting in settings)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+                    ImGui.Indent();
+                    ImGui.Text(setting.uniqueLabel);
+                    ImGui.Unindent();
+                    ImGui.TableNextColumn();
+                    bool valueChanged = DrawSetting(setting);
+                    changed |= valueChanged;
+                }
+            }
+
+            ImGui.EndTable();
+            ImGui.NewLine();
+
+            return changed;
+        }
+
+        public static bool DrawSettings(UIControlledSetting[] settings)
+        {
+            ImGui.NewLine();
+
+            bool changed = false;
+
+            foreach (var setting in settings)
+            {
+                changed |= DrawSetting(setting);
+            }
+
+            ImGui.NewLine();
+            return changed;
+        }
+
+        public static bool DrawSetting(UIControlledSetting setting)
+        {
+            return setting.DrawGUIControl();
+        }
+    }
+}

--- a/T3/Gui/SettingsUi.cs
+++ b/T3/Gui/SettingsUi.cs
@@ -41,6 +41,11 @@ namespace t3.Gui
             return changed;
         }
 
+        /// <summary>
+        /// Draws a series of settings in order
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
         public static bool DrawSettings(UIControlledSetting[] settings)
         {
             ImGui.NewLine();

--- a/T3/Gui/SettingsUi.cs
+++ b/T3/Gui/SettingsUi.cs
@@ -2,6 +2,7 @@ using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using T3.Gui.Windows;
@@ -27,11 +28,26 @@ namespace t3.Gui
                     ImGui.TableNextRow();
                     ImGui.TableNextColumn();
                     ImGui.Indent();
-                    ImGui.Text(setting.uniqueLabel);
-                    ImGui.Unindent();
-                    ImGui.TableNextColumn();
-                    bool valueChanged = DrawSetting(setting);
-                    changed |= valueChanged;
+
+                    if (setting.DrawOnLeft)
+                    {
+                        var valueChanged = setting.DrawGUIControl(true);
+                        changed |= valueChanged;
+                        ImGui.SameLine();
+                        ImGui.Dummy(_leftCheckboxSpacing);
+                        ImGui.SameLine();
+                        ImGui.Text(setting.CleanLabel);
+                        ImGui.Unindent();
+                    }
+                    else
+                    {
+                        ImGui.Text(setting.CleanLabel);
+                        ImGui.Unindent();
+                        ImGui.TableNextColumn();
+                        var valueChanged = setting.DrawGUIControl(true);
+                        changed |= valueChanged;
+                    }
+
                 }
             }
 
@@ -54,16 +70,15 @@ namespace t3.Gui
 
             foreach (var setting in settings)
             {
-                changed |= DrawSetting(setting);
+                ImGui.Text(setting.CleanLabel);
+                ImGui.SameLine();
+                changed |= setting.DrawGUIControl(true);
             }
 
             ImGui.NewLine();
             return changed;
         }
 
-        public static bool DrawSetting(UIControlledSetting setting)
-        {
-            return setting.DrawGUIControl();
-        }
+        private static readonly Vector2 _leftCheckboxSpacing = new Vector2(0f, 20f);
     }
 }

--- a/T3/Gui/Styling/CustomComponents.cs
+++ b/T3/Gui/Styling/CustomComponents.cs
@@ -487,10 +487,19 @@ namespace T3.Gui
 
             ImGui.SameLine();
             ImGui.SetCursorPosX(leftPadding + 20);
-            var size = new Vector2(150, ImGui.GetFrameHeight());
+            var modified = DrawSingleValueEdit(cleanedLabel, ref value, min, max, clamp, scale);
+
+            return modified;
+        }
+
+        public static bool FloatValueEditInPlace(string label, ref float value, float min = float.NegativeInfinity, float max = float.PositiveInfinity, float scale = 0.01f, bool clamp = false)
+        {
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
+            ImGui.SameLine();
             ImGui.PushID(label);
-            var result = SingleValueEdit.Draw(ref value, size, min, max, clamp, scale);
-            var modified = (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
+            var modified = DrawSingleValueEdit(cleanedLabel, ref value, min, max, clamp, scale);
+
             ImGui.PopID();
             return modified;
         }
@@ -510,12 +519,27 @@ namespace T3.Gui
 
             ImGui.SameLine();
             ImGui.SetCursorPosX(leftPadding + 20);
-            var size = new Vector2(150, ImGui.GetFrameHeight());
-            ImGui.PushID(label);
-            var result = SingleValueEdit.Draw(ref value, size, min, max, true, scale);
-            var modified = (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
-            ImGui.PopID();
+
+            var modified = DrawSingleValueEdit(cleanedLabel, ref value, min, max, true, scale);
             return modified;
+        }
+
+        public static bool DrawSingleValueEdit(string label, ref int value, int min = int.MinValue, int max = int.MaxValue, bool clamp = false, float scale = 1f)
+        {
+            ImGui.PushID(label);
+            var size = new Vector2(150, ImGui.GetFrameHeight());
+            var result = SingleValueEdit.Draw(ref value, size, min, max, clamp, scale);
+            ImGui.PopID();
+            return (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
+        }
+
+        public static bool DrawSingleValueEdit(string label, ref float value, float min = float.MinValue, float max = float.MaxValue, bool clamp = false, float scale = 1f)
+        {
+            ImGui.PushID(label);
+            var size = new Vector2(150, ImGui.GetFrameHeight());
+            var result = SingleValueEdit.Draw(ref value, size, min, max, clamp, scale);
+            ImGui.PopID();
+            return (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
         }
 
         public static bool StringValueEdit(string label, ref string value)
@@ -578,7 +602,6 @@ namespace T3.Gui
             var modified = ImGui.Combo($"##dropDown{enumType}{label}", ref index, valueNames, valueNames.Length, valueNames.Length);
             return modified;
         }
-
 
         private const string _idSpecifier = "##";
     }

--- a/T3/Gui/Styling/CustomComponents.cs
+++ b/T3/Gui/Styling/CustomComponents.cs
@@ -473,21 +473,23 @@ namespace T3.Gui
         }
 
 
-        public static bool FloatValueEdit(string label, ref float value, float min= float.NegativeInfinity, float max= float.PositiveInfinity, float scale= 0)
+        public static bool FloatValueEdit(string label, ref float value, float min = float.NegativeInfinity, float max = float.PositiveInfinity, float scale = 0.01f, bool clamp = false)
         {
             var labelSize = ImGui.CalcTextSize(label);
             const float leftPadding = 200;
             var p = ImGui.GetCursorPos();
-            ImGui.SetCursorPosX( MathF.Max(leftPadding - labelSize.X,0)+10);
+            ImGui.SetCursorPosX(MathF.Max(leftPadding - labelSize.X, 0) + 10);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(label);
+
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
             ImGui.SetCursorPos(p);
-            
+
             ImGui.SameLine();
             ImGui.SetCursorPosX(leftPadding + 20);
             var size = new Vector2(150, ImGui.GetFrameHeight());
             ImGui.PushID(label);
-            var result = SingleValueEdit.Draw(ref value, size, min, max);
+            var result = SingleValueEdit.Draw(ref value, size, min, max, clamp, scale);
             var modified = (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
             ImGui.PopID();
             return modified;
@@ -500,7 +502,10 @@ namespace T3.Gui
             var p = ImGui.GetCursorPos();
             ImGui.SetCursorPosX(MathF.Max(leftPadding - labelSize.X, 0) + 10);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(label);
+
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
+
             ImGui.SetCursorPos(p);
 
             ImGui.SameLine();
@@ -521,7 +526,10 @@ namespace T3.Gui
             var p = ImGui.GetCursorPos();
             ImGui.SetCursorPosX( MathF.Max(leftPadding - labelSize.X,0)+10);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(label);
+
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
+
             ImGui.SetCursorPos(p);
             
             ImGui.SameLine();
@@ -541,7 +549,10 @@ namespace T3.Gui
             var p = ImGui.GetCursorPos();
             ImGui.SetCursorPosX(MathF.Max(200 - labelSize.X, 0) + 10);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(label);
+
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
+
             ImGui.SetCursorPos(p);
 
             // Dropdown
@@ -567,6 +578,9 @@ namespace T3.Gui
             var modified = ImGui.Combo($"##dropDown{enumType}{label}", ref index, valueNames, valueNames.Length, valueNames.Length);
             return modified;
         }
+
+
+        private const string _idSpecifier = "##";
     }
 
     public static class InputWithTypeAheadSearch
@@ -665,6 +679,6 @@ namespace T3.Gui
 
         private static List<string> _lastResults = new List<string>();
         private static int _selectedResultIndex = 0;
-        private static bool _isSearchResultWindowOpen;        
+        private static bool _isSearchResultWindowOpen;
     }
 }

--- a/T3/Gui/UiHelpers/UIControlledSetting.cs
+++ b/T3/Gui/UiHelpers/UIControlledSetting.cs
@@ -63,20 +63,15 @@ namespace T3.Gui.Windows
         /// If an Action was provided in constructor, it will be executed when value is changed. </returns>
         public bool DrawGUIControl()
         {
-            //if (!string.IsNullOrEmpty(tooltip))
-            //{
-            //    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-            //    {
-            //        ImGui.SetTooltip(tooltip);
-            //    }
-            //}
-
-            var changed = guiFunc.Invoke();
-
             if (!string.IsNullOrEmpty(tooltip))
             {
-                CustomComponents.TooltipForLastItem(tooltip, additionalNotes);
+                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                {
+                    ImGui.SetTooltip(tooltip);
+                }
             }
+
+            var changed = guiFunc.Invoke();
 
             if(changed)
             {

--- a/T3/Gui/UiHelpers/UIControlledSetting.cs
+++ b/T3/Gui/UiHelpers/UIControlledSetting.cs
@@ -1,0 +1,89 @@
+using ImGuiNET;
+using System;
+using T3.Gui.UiHelpers;
+
+namespace T3.Gui.Windows
+{
+    public class UIControlledSetting
+    {
+        /// <summary>
+        /// The generated unique label
+        /// </summary>
+        public string uniqueLabel { get; private set; }
+
+        /// <summary>
+        /// The label provided in the constructor
+        /// Unused by this class and here for convenience, but often best left ignored
+        /// </summary>
+        public string cleanLabel { get; private set; }
+
+        private string tooltip;
+        private string additionalNotes;
+        private Func<bool> guiFunc;
+        private Action OnValueChanged;
+
+        // Cheaper than GUIDs
+        // In case we want to have the same variable be changeable with different UI controls
+        // or if multiple settings have the same label
+        static ushort countForUniqueID = ushort.MaxValue;
+
+        /// <summary>
+        /// For the sake of simple use of the optional parameters and populating/maintaining many settings, the recommended way to call this constructor is:
+        /// <code>
+        /// new UIControlledSetting
+        /// (
+        ///    label: "My Setting",
+        ///    tooltip: "The global scale of all rendered UI in the application",
+        ///    guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.UiScaleFactor, 0.01f, 0.5f, 3f),
+        ///    OnValueChanged: () => //your action
+        /// );
+        /// </code>
+        /// </summary>
+        /// <param name="label">The label to display next to the gui control</param>
+        /// <param name="guiFunc">The <see cref="ImGuiNET"/> - based function that draws the setting control and
+        /// returns true if the control was changed. The input to this function see is a unique ID based on the label provided</param>
+        /// <param name="tooltip">Tooltip displayed when hovering over the control</param>
+        /// <param name="additionalNotes">Additional notes displayed alongside the tooltip</param>
+        /// <param name="OnValueChanged">An action performed when the value is changed</param>
+        public UIControlledSetting(string label, Func<string, bool> guiFunc, string tooltip = null, string additionalNotes = null, Action OnValueChanged = null)
+        {
+            cleanLabel = label;
+            uniqueLabel = $"{label}##{countForUniqueID--}";
+
+            this.guiFunc = () => guiFunc(uniqueLabel);
+            this.tooltip = tooltip;
+            this.additionalNotes = additionalNotes;
+            this.OnValueChanged = OnValueChanged;
+        }
+
+        /// <summary>
+        /// Draws the GUI for this setting using the Func provided in its constructor
+        /// </summary>
+        /// <returns>True if changed, false if unchanged.
+        /// If an Action was provided in constructor, it will be executed when value is changed. </returns>
+        public bool DrawGUIControl()
+        {
+            //if (!string.IsNullOrEmpty(tooltip))
+            //{
+            //    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            //    {
+            //        ImGui.SetTooltip(tooltip);
+            //    }
+            //}
+
+            var changed = guiFunc.Invoke();
+
+            if (!string.IsNullOrEmpty(tooltip))
+            {
+                CustomComponents.TooltipForLastItem(tooltip, additionalNotes);
+            }
+
+            if(changed)
+            {
+                OnValueChanged?.Invoke();
+            }
+
+            return changed;
+        }
+    }
+}

--- a/T3/Gui/UiHelpers/UserSettings.cs
+++ b/T3/Gui/UiHelpers/UserSettings.cs
@@ -56,6 +56,7 @@ namespace T3.Gui.UiHelpers
             public float ScrollSmoothing = 0.06f;
             public float TooltipDelay = 1.2f;
             public float ClickThreshold = 5; // Increase for high-res display and pen tablets
+            public bool SymbolBrowserDescriptionTimeout = false;
 
             public float KeyboardScrollAcceleration = 2.5f;
 

--- a/T3/Gui/Windows/SettingsInSettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsInSettingsWindow.cs
@@ -1,7 +1,6 @@
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.Windows.Forms;
 using ImGuiNET;
+using System;
+using System.Numerics;
 using T3.Gui.Graph;
 using T3.Gui.UiHelpers;
 
@@ -16,70 +15,77 @@ namespace T3.Gui.Windows
                 label: "Warn before Lib modifications",
                 tooltip: "This warning pops up when you attempt to enter an Operator that ships with the application.\n" +
                          "If unsure, this is best left checked.",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.WarnBeforeLibEdit)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.WarnBeforeLibEdit),
+                drawOnLeft: true
             ),
 
             new UIControlledSetting
             (
                 label: "Use arc connections",
                 tooltip: "Affects the shape of the connections between your Operators",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.UseArcConnections)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.UseArcConnections),
+                drawOnLeft: true
             ),
 
             new UIControlledSetting
             (
                 label: "Use Jog Dial Control",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.UseJogDialControl)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.UseJogDialControl),
+                drawOnLeft: true
             ),
 
             new UIControlledSetting
             (
                 label: "Show Graph thumbnails",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowThumbnails)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowThumbnails),
+                drawOnLeft: true
             ),
 
             new UIControlledSetting
             (
                 label: "Drag snapped nodes",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SmartGroupDragging)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SmartGroupDragging),
+                drawOnLeft: true
             ),
 
             new UIControlledSetting
             (
                 label: "Fullscreen Window Swap",
                 tooltip: "Swap main and second windows when fullscreen",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen),
+                drawOnLeft: true
             ),
 
             new UIControlledSetting
             (
                 label: "UI Scale",
                 tooltip: "The global scale of all rendered UI in the application",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.UiScaleFactor, 0.01f, 3f)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.UiScaleFactor, 0.1f, 5f, true, 0.01f)
             ),
 
             new UIControlledSetting
             (
                 label: "Scroll smoothing",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.ScrollSmoothing)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.ScrollSmoothing, 0f, 0.2f, true, 0.01f)
             ),
 
             new UIControlledSetting
             (
                 label: "Snap strength",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.SnapStrength)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.SnapStrength)
             ),
 
             new UIControlledSetting
             (
                 label: "Click threshold",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.ClickThreshold)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.ClickThreshold)
+
             ),
 
             new UIControlledSetting
             (
                 label: "Timeline Raster Density",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.TimeRasterDensity)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.TimeRasterDensity)
             ),
         };
 
@@ -88,19 +94,19 @@ namespace T3.Gui.Windows
             new UIControlledSetting
             (
                 label: "Smoothing",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseDamping, 0.01f, 1f)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseDamping, 0.01f, 1f)
             ),
 
             new UIControlledSetting
             (
                 label: "Move Speed",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseMoveSpeedFactor, 0, 10f)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseMoveSpeedFactor, 0, 10f)
             ),
 
             new UIControlledSetting
             (
                 label: "Rotation Speed",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseRotationSpeedFactor, 0, 10f)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseRotationSpeedFactor, 0, 10f)
             )
         };
 
@@ -109,13 +115,13 @@ namespace T3.Gui.Windows
             new UIControlledSetting
             (
                 label: "Gizmo size",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.GizmoSize)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.GizmoSize)
             ),
 
             new UIControlledSetting
             (
                 label: "Tooltip delay",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.TooltipDelay)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.TooltipDelay)
             ),
 
 
@@ -139,19 +145,22 @@ namespace T3.Gui.Windows
             new UIControlledSetting
             (
                 label: "VSync",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UseVSync)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UseVSync),
+                drawOnLeft: true
             ),
 
             new UIControlledSetting
             (
                 label: "Show Window Regions",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref WindowRegionsVisible)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref WindowRegionsVisible),
+                drawOnLeft: true
             ),
 
             new UIControlledSetting
             (
                 label: "Show Item Regions",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref ItemRegionsVisible)
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref ItemRegionsVisible),
+                drawOnLeft: true
             ),
         };
 
@@ -166,31 +175,31 @@ namespace T3.Gui.Windows
             new UIControlledSetting
             (
                 label: "Height Connection Zone",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.UsableSlotThickness)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.UsableSlotThickness)
             ),
 
             new UIControlledSetting
             (
                 label: "Slot Gaps",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.SlotGaps, 0, 10f)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.SlotGaps, 0, 10f)
             ),
 
             new UIControlledSetting
             (
                 label: "Input Slot Margin Y",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.InputSlotMargin, 0, 10f)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.InputSlotMargin, 0, 10f)
             ),
 
             new UIControlledSetting
             (
                 label: "Input Slot Thickness",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.InputSlotThickness, 0, 10f)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.InputSlotThickness, 0, 10f)
             ),
 
             new UIControlledSetting
             (
                 label: "Output Slot Margin",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.OutputSlotMargin, 0, 10f)
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.OutputSlotMargin, 0, 10f)
             ),
 
             new UIControlledSetting
@@ -205,5 +214,6 @@ namespace T3.Gui.Windows
                 guiFunc: (string guiLabel) => ImGui.ColorEdit4(guiLabel, ref T3Style.Colors.ValueLabelColorHover.Rgba)
             ),
         };
+
     }
 }

--- a/T3/Gui/Windows/SettingsInSettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsInSettingsWindow.cs
@@ -1,4 +1,6 @@
-using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
 using ImGuiNET;
 using T3.Gui.Graph;
 using T3.Gui.UiHelpers;
@@ -7,202 +9,201 @@ namespace T3.Gui.Windows
 {
     public partial class SettingsWindow
     {
-        class UIControlledSetting
-        {
-            public string label;
-            public string tooltip;
-            public Func<bool> imguiFunc;
-            public Action OnValueChanged;
-        }
-
         static readonly UIControlledSetting[] userInterfaceSettings = new UIControlledSetting[]
         {
-            new UIControlledSetting()
-            {
-                label = "UI Scale",
-                imguiFunc = () => ImGui.DragFloat("##UiScaleFactor", ref UserSettings.Config.UiScaleFactor, 0.01f, 0.5f, 3f)
-            },
+            new UIControlledSetting
+            (
+                label: "UI Scale",
+                tooltip: "The global scale of all rendered UI in the application",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.UiScaleFactor, 0.01f, 3f)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Warn before Lib modifications",
-                imguiFunc = () => ImGui.Checkbox("##WarnBeforeLibEdit", ref UserSettings.Config.WarnBeforeLibEdit)
-            },
+            new UIControlledSetting
+            (
+                label: "Warn before Lib modifications",
+                tooltip: "This warning pops up when you attempt to enter an Operator that ships with the application.\n" +
+                         "If unsure, this is best left checked.",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.WarnBeforeLibEdit)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Use arc connections",
-                imguiFunc = () => ImGui.Checkbox("##UseArcConnections", ref UserSettings.Config.UseArcConnections)
-            },
+            new UIControlledSetting
+            (
+                label: "Use arc connections",
+                tooltip: "Affects the shape of the connections between your Operators",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.UseArcConnections)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Use Jog Dial Control",
-                imguiFunc = () => ImGui.Checkbox("##UseJogDialControl", ref UserSettings.Config.UseJogDialControl)
-            },
+            new UIControlledSetting
+            (
+                label: "Use Jog Dial Control",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.UseJogDialControl)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Scroll smoothing",
-                imguiFunc = () => ImGui.DragFloat("##ScrollSmoothing", ref UserSettings.Config.ScrollSmoothing)
-            },
+            new UIControlledSetting
+            (
+                label: "Scroll smoothing",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.ScrollSmoothing)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Show Graph thumbnails",
-                imguiFunc = () => ImGui.Checkbox("##ShowThumbnails", ref UserSettings.Config.ShowThumbnails)
-            },
+            new UIControlledSetting
+            (
+                label: "Show Graph thumbnails",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowThumbnails)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Drag snapped nodes",
-                imguiFunc = () => ImGui.Checkbox("##SmartGroupDragging", ref UserSettings.Config.SmartGroupDragging)
-            },
+            new UIControlledSetting
+            (
+                label: "Drag snapped nodes",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SmartGroupDragging)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Snap strength",
-                imguiFunc = () => ImGui.DragFloat("##SnapStrength", ref UserSettings.Config.SnapStrength)
-            },
+            new UIControlledSetting
+            (
+                label: "Snap strength",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.SnapStrength)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Click threshold",
-                imguiFunc = () => ImGui.DragFloat("##ClickThreshold", ref UserSettings.Config.ClickThreshold)
-            },
+            new UIControlledSetting
+            (
+                label: "Click threshold",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.ClickThreshold)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Timeline Raster Density",
-                imguiFunc = () => ImGui.DragFloat("##TimeRasterDensity", ref UserSettings.Config.TimeRasterDensity, 0.01f)
-            },
+            new UIControlledSetting
+            (
+                label: "Timeline Raster Density",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.TimeRasterDensity)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Fullscreen Window Swap",
-                tooltip = "Swap main and second windows when fullscreen",
-                imguiFunc = () => ImGui.Checkbox("##SwapMainAnd2ndWindowsWhenFullscreen", ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen)
-            },
+            new UIControlledSetting
+            (
+                label: "Fullscreen Window Swap",
+                tooltip: "Swap main and second windows when fullscreen",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen)
+            ),
         };
 
         static readonly UIControlledSetting[] spaceMouseSettings = new UIControlledSetting[]
         {
-            new UIControlledSetting()
-            {
-                label = "Smoothing",
-                imguiFunc = () => ImGui.DragFloat("##SpaceMouseDamping", ref UserSettings.Config.SpaceMouseDamping, 0.01f, 0.01f, 1f)
-            },
+            new UIControlledSetting
+            (
+                label: "Smoothing",
+                guiFunc: (string guiLabel) => ImGui.DragFloat(guiLabel, ref UserSettings.Config.SpaceMouseDamping, 0.01f, 0.01f, 1f)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Move Speed",
-                imguiFunc = () => ImGui.DragFloat("##SpaceMouseMoveSpeedFactor", ref UserSettings.Config.SpaceMouseMoveSpeedFactor, 0.01f, 0, 10f)
-            },
+            new UIControlledSetting
+            (
+                label: "Move Speed",
+                guiFunc: (string guiLabel) => ImGui.DragFloat(guiLabel, ref UserSettings.Config.SpaceMouseMoveSpeedFactor, 0.01f, 0, 10f)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Rotation Speed",
-                imguiFunc = () => ImGui.DragFloat("##SpaceMouseRotationSpeedFactor", ref UserSettings.Config.SpaceMouseRotationSpeedFactor, 0.01f, 0, 10f)
-            }
+            new UIControlledSetting
+            (
+                label: "Rotation Speed",
+                guiFunc: (string guiLabel) => ImGui.DragFloat(guiLabel, ref UserSettings.Config.SpaceMouseRotationSpeedFactor, 0.01f, 0, 10f)
+            )
         };
 
         static readonly UIControlledSetting[] additionalSettings = new UIControlledSetting[]
         {
-            new UIControlledSetting()
-            {
-                label = "Gizmo size",
-                imguiFunc = () => ImGui.DragFloat("##GizmoSize", ref UserSettings.Config.GizmoSize)
-            },
+            new UIControlledSetting
+            (
+                label: "Gizmo size",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.GizmoSize)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Tooltip delay",
-                imguiFunc = () => ImGui.DragFloat("##TooltipDelay", ref UserSettings.Config.TooltipDelay)
-            },
+            new UIControlledSetting
+            (
+                label: "Tooltip delay",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.TooltipDelay)
+            ),
 
-            //new SettingInfo()
-            //{
-            //    label = "Show Title",
-            //    imguiFunc = () => ImGui.Checkbox("##ShowTitleAndDescription", ref UserSettings.Config.ShowTitleAndDescription)
-            //},
 
-            //new SettingInfo()
-            //{
-            //    label = "Show Timeline",
-            //    imguiFunc = () => ImGui.Checkbox("##ShowTimeline", ref UserSettings.Config.ShowTimeline)
-            //}
+            // These settings were laid out in the old UI, kept here for someone else to ultimately choose to yeet or unyeet them
+
+            //new UIControlledSetting
+            //(
+            //    label: "Show Title",
+            //    guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowTitleAndDescription)
+            //),
+
+            //new UIControlledSetting
+            //(
+            //    label: "Show Timeline",
+            //    guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowTimeline)
+            //)
         };
         
         static readonly UIControlledSetting[] debugSettings = new UIControlledSetting[]
         {
-            new UIControlledSetting()
-            {
-                label = "VSync",
-                imguiFunc = () => ImGui.Checkbox("##UseVSync", ref UseVSync)
-            },
+            new UIControlledSetting
+            (
+                label: "VSync",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UseVSync)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Show Window Regions",
-                imguiFunc = () => ImGui.Checkbox("##WindowRegionsVisible", ref WindowRegionsVisible)
-            },
+            new UIControlledSetting
+            (
+                label: "Show Window Regions",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref WindowRegionsVisible)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Show Item Regions",
-                imguiFunc = () => ImGui.Checkbox("##ItemRegionsVisible", ref ItemRegionsVisible)
-            },
+            new UIControlledSetting
+            (
+                label: "Show Item Regions",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref ItemRegionsVisible)
+            ),
         };
 
         static readonly UIControlledSetting[] t3UiStyleSettings = new UIControlledSetting[]
         {
-            new UIControlledSetting()
-            {
-                label = "Height Connection Zone",
-                imguiFunc = () => ImGui.DragFloat("##UsableSlotThickness", ref GraphNode.UsableSlotThickness)
-            },
+            new UIControlledSetting
+            (
+                label: "Height Connection Zone",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.UsableSlotThickness)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Label position",
-                imguiFunc = () => ImGui.DragFloat2("##LabelPos", ref GraphNode.LabelPos)
-            },
+            new UIControlledSetting
+            (
+                label: "Label position",
+                guiFunc: (string guiLabel) => ImGui.DragFloat2(guiLabel, ref GraphNode.LabelPos)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Slot Gaps",
-                imguiFunc = () => ImGui.DragFloat("##SlotGaps", ref GraphNode.SlotGaps, 0.1f, 0, 10f)
-            },
+            new UIControlledSetting
+            (
+                label: "Slot Gaps",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.SlotGaps, 0, 10f)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Input Slot Margin Y",
-                imguiFunc = () => ImGui.DragFloat("##InputSlotMargin", ref GraphNode.InputSlotMargin, 0.1f, 0, 10f)
-            },
+            new UIControlledSetting
+            (
+                label: "Input Slot Margin Y",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.InputSlotMargin, 0, 10f)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Input Slot Thickness",
-                imguiFunc = () => ImGui.DragFloat("##InputSlotThickness", ref GraphNode.InputSlotThickness, 0.1f, 0, 10f)
-            },
+            new UIControlledSetting
+            (
+                label: "Input Slot Thickness",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.InputSlotThickness, 0, 10f)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Output Slot Margin",
-                imguiFunc = () => ImGui.DragFloat("##OutputSlotMargin", ref GraphNode.OutputSlotMargin, 0.1f, 0, 10f)
-            },
+            new UIControlledSetting
+            (
+                label: "Output Slot Margin",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.OutputSlotMargin, 0, 10f)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Value Label Color",
-                imguiFunc = () => ImGui.ColorEdit4("##ValueLabelColor", ref T3Style.Colors.ValueLabelColor.Rgba)
-            },
+            new UIControlledSetting
+            (
+                label: "Value Label Color",
+                guiFunc: (string guiLabel) => ImGui.ColorEdit4(guiLabel, ref T3Style.Colors.ValueLabelColor.Rgba)
+            ),
 
-            new UIControlledSetting()
-            {
-                label = "Value Label Color Hover",
-                imguiFunc = () => ImGui.ColorEdit4("##ValueLabelColorHover", ref T3Style.Colors.ValueLabelColorHover.Rgba)
-            },
+            new UIControlledSetting
+            (
+                label: "Value Label Color Hover",
+                guiFunc: (string guiLabel) => ImGui.ColorEdit4(guiLabel, ref T3Style.Colors.ValueLabelColorHover.Rgba)
+            ),
         };
     }
 }

--- a/T3/Gui/Windows/SettingsInSettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsInSettingsWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using ImGuiNET;
+using T3.Gui.Graph;
 using T3.Gui.UiHelpers;
 
 namespace T3.Gui.Windows
@@ -130,6 +131,78 @@ namespace T3.Gui.Windows
             //    label = "Show Timeline",
             //    imguiFunc = () => ImGui.Checkbox("##ShowTimeline", ref UserSettings.Config.ShowTimeline)
             //}
+        };
+        
+        static readonly UIControlledSetting[] debugSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting()
+            {
+                label = "VSync",
+                imguiFunc = () => ImGui.Checkbox("##UseVSync", ref UseVSync)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Show Window Regions",
+                imguiFunc = () => ImGui.Checkbox("##WindowRegionsVisible", ref WindowRegionsVisible)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Show Item Regions",
+                imguiFunc = () => ImGui.Checkbox("##ItemRegionsVisible", ref ItemRegionsVisible)
+            },
+        };
+
+        static readonly UIControlledSetting[] t3UiStyleSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting()
+            {
+                label = "Height Connection Zone",
+                imguiFunc = () => ImGui.DragFloat("##UsableSlotThickness", ref GraphNode.UsableSlotThickness)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Label position",
+                imguiFunc = () => ImGui.DragFloat2("##LabelPos", ref GraphNode.LabelPos)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Slot Gaps",
+                imguiFunc = () => ImGui.DragFloat("##SlotGaps", ref GraphNode.SlotGaps, 0.1f, 0, 10f)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Input Slot Margin Y",
+                imguiFunc = () => ImGui.DragFloat("##InputSlotMargin", ref GraphNode.InputSlotMargin, 0.1f, 0, 10f)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Input Slot Thickness",
+                imguiFunc = () => ImGui.DragFloat("##InputSlotThickness", ref GraphNode.InputSlotThickness, 0.1f, 0, 10f)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Output Slot Margin",
+                imguiFunc = () => ImGui.DragFloat("##OutputSlotMargin", ref GraphNode.OutputSlotMargin, 0.1f, 0, 10f)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Value Label Color",
+                imguiFunc = () => ImGui.ColorEdit4("##ValueLabelColor", ref T3Style.Colors.ValueLabelColor.Rgba)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Value Label Color Hover",
+                imguiFunc = () => ImGui.ColorEdit4("##ValueLabelColorHover", ref T3Style.Colors.ValueLabelColorHover.Rgba)
+            },
         };
     }
 }

--- a/T3/Gui/Windows/SettingsInSettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsInSettingsWindow.cs
@@ -88,19 +88,19 @@ namespace T3.Gui.Windows
             new UIControlledSetting
             (
                 label: "Smoothing",
-                guiFunc: (string guiLabel) => ImGui.DragFloat(guiLabel, ref UserSettings.Config.SpaceMouseDamping, 0.01f, 0.01f, 1f)
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseDamping, 0.01f, 1f)
             ),
 
             new UIControlledSetting
             (
                 label: "Move Speed",
-                guiFunc: (string guiLabel) => ImGui.DragFloat(guiLabel, ref UserSettings.Config.SpaceMouseMoveSpeedFactor, 0.01f, 0, 10f)
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseMoveSpeedFactor, 0, 10f)
             ),
 
             new UIControlledSetting
             (
                 label: "Rotation Speed",
-                guiFunc: (string guiLabel) => ImGui.DragFloat(guiLabel, ref UserSettings.Config.SpaceMouseRotationSpeedFactor, 0.01f, 0, 10f)
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseRotationSpeedFactor, 0, 10f)
             )
         };
 

--- a/T3/Gui/Windows/SettingsInSettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsInSettingsWindow.cs
@@ -13,13 +13,6 @@ namespace T3.Gui.Windows
         {
             new UIControlledSetting
             (
-                label: "UI Scale",
-                tooltip: "The global scale of all rendered UI in the application",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.UiScaleFactor, 0.01f, 3f)
-            ),
-
-            new UIControlledSetting
-            (
                 label: "Warn before Lib modifications",
                 tooltip: "This warning pops up when you attempt to enter an Operator that ships with the application.\n" +
                          "If unsure, this is best left checked.",
@@ -41,12 +34,6 @@ namespace T3.Gui.Windows
 
             new UIControlledSetting
             (
-                label: "Scroll smoothing",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.ScrollSmoothing)
-            ),
-
-            new UIControlledSetting
-            (
                 label: "Show Graph thumbnails",
                 guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowThumbnails)
             ),
@@ -55,6 +42,26 @@ namespace T3.Gui.Windows
             (
                 label: "Drag snapped nodes",
                 guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SmartGroupDragging)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Fullscreen Window Swap",
+                tooltip: "Swap main and second windows when fullscreen",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "UI Scale",
+                tooltip: "The global scale of all rendered UI in the application",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.UiScaleFactor, 0.01f, 3f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Scroll smoothing",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.ScrollSmoothing)
             ),
 
             new UIControlledSetting
@@ -73,13 +80,6 @@ namespace T3.Gui.Windows
             (
                 label: "Timeline Raster Density",
                 guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.TimeRasterDensity)
-            ),
-
-            new UIControlledSetting
-            (
-                label: "Fullscreen Window Swap",
-                tooltip: "Swap main and second windows when fullscreen",
-                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen)
             ),
         };
 
@@ -159,14 +159,14 @@ namespace T3.Gui.Windows
         {
             new UIControlledSetting
             (
-                label: "Height Connection Zone",
-                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.UsableSlotThickness)
+                label: "Label position",
+                guiFunc: (string guiLabel) => ImGui.DragFloat2(guiLabel, ref GraphNode.LabelPos)
             ),
 
             new UIControlledSetting
             (
-                label: "Label position",
-                guiFunc: (string guiLabel) => ImGui.DragFloat2(guiLabel, ref GraphNode.LabelPos)
+                label: "Height Connection Zone",
+                guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref GraphNode.UsableSlotThickness)
             ),
 
             new UIControlledSetting

--- a/T3/Gui/Windows/SettingsInSettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsInSettingsWindow.cs
@@ -1,0 +1,135 @@
+using System;
+using ImGuiNET;
+using T3.Gui.UiHelpers;
+
+namespace T3.Gui.Windows
+{
+    public partial class SettingsWindow
+    {
+        class UIControlledSetting
+        {
+            public string label;
+            public string tooltip;
+            public Func<bool> imguiFunc;
+            public Action OnValueChanged;
+        }
+
+        static readonly UIControlledSetting[] userInterfaceSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting()
+            {
+                label = "UI Scale",
+                imguiFunc = () => ImGui.DragFloat("##UiScaleFactor", ref UserSettings.Config.UiScaleFactor, 0.01f, 0.5f, 3f)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Warn before Lib modifications",
+                imguiFunc = () => ImGui.Checkbox("##WarnBeforeLibEdit", ref UserSettings.Config.WarnBeforeLibEdit)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Use arc connections",
+                imguiFunc = () => ImGui.Checkbox("##UseArcConnections", ref UserSettings.Config.UseArcConnections)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Use Jog Dial Control",
+                imguiFunc = () => ImGui.Checkbox("##UseJogDialControl", ref UserSettings.Config.UseJogDialControl)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Scroll smoothing",
+                imguiFunc = () => ImGui.DragFloat("##ScrollSmoothing", ref UserSettings.Config.ScrollSmoothing)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Show Graph thumbnails",
+                imguiFunc = () => ImGui.Checkbox("##ShowThumbnails", ref UserSettings.Config.ShowThumbnails)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Drag snapped nodes",
+                imguiFunc = () => ImGui.Checkbox("##SmartGroupDragging", ref UserSettings.Config.SmartGroupDragging)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Snap strength",
+                imguiFunc = () => ImGui.DragFloat("##SnapStrength", ref UserSettings.Config.SnapStrength)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Click threshold",
+                imguiFunc = () => ImGui.DragFloat("##ClickThreshold", ref UserSettings.Config.ClickThreshold)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Timeline Raster Density",
+                imguiFunc = () => ImGui.DragFloat("##TimeRasterDensity", ref UserSettings.Config.TimeRasterDensity, 0.01f)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Fullscreen Window Swap",
+                tooltip = "Swap main and second windows when fullscreen",
+                imguiFunc = () => ImGui.Checkbox("##SwapMainAnd2ndWindowsWhenFullscreen", ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen)
+            },
+        };
+
+        static readonly UIControlledSetting[] spaceMouseSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting()
+            {
+                label = "Smoothing",
+                imguiFunc = () => ImGui.DragFloat("##SpaceMouseDamping", ref UserSettings.Config.SpaceMouseDamping, 0.01f, 0.01f, 1f)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Move Speed",
+                imguiFunc = () => ImGui.DragFloat("##SpaceMouseMoveSpeedFactor", ref UserSettings.Config.SpaceMouseMoveSpeedFactor, 0.01f, 0, 10f)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Rotation Speed",
+                imguiFunc = () => ImGui.DragFloat("##SpaceMouseRotationSpeedFactor", ref UserSettings.Config.SpaceMouseRotationSpeedFactor, 0.01f, 0, 10f)
+            }
+        };
+
+        static readonly UIControlledSetting[] additionalSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting()
+            {
+                label = "Gizmo size",
+                imguiFunc = () => ImGui.DragFloat("##GizmoSize", ref UserSettings.Config.GizmoSize)
+            },
+
+            new UIControlledSetting()
+            {
+                label = "Tooltip delay",
+                imguiFunc = () => ImGui.DragFloat("##TooltipDelay", ref UserSettings.Config.TooltipDelay)
+            },
+
+            //new SettingInfo()
+            //{
+            //    label = "Show Title",
+            //    imguiFunc = () => ImGui.Checkbox("##ShowTitleAndDescription", ref UserSettings.Config.ShowTitleAndDescription)
+            //},
+
+            //new SettingInfo()
+            //{
+            //    label = "Show Timeline",
+            //    imguiFunc = () => ImGui.Checkbox("##ShowTimeline", ref UserSettings.Config.ShowTimeline)
+            //}
+        };
+    }
+}

--- a/T3/Gui/Windows/SettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsWindow.cs
@@ -29,19 +29,19 @@ namespace T3.Gui.Windows
             ImGui.NewLine();
             if (ImGui.TreeNode("User Interface"))
             {
-                changed |= SettingsUi.DrawSettings(userInterfaceSettings);
+                changed |= SettingsUi.DrawSettingsTable("##uisettingstable", userInterfaceSettings);
                 ImGui.TreePop();
             }
             
             if (ImGui.TreeNode("Space Mouse"))
             {
-                changed |= SettingsUi.DrawSettings(spaceMouseSettings);
+                changed |= SettingsUi.DrawSettingsTable("##settingspacemousetable", spaceMouseSettings);
                 ImGui.TreePop();
             }
 
             if (ImGui.TreeNode("Additional settings"))
             {
-                changed |= SettingsUi.DrawSettings(additionalSettings);
+                changed |= SettingsUi.DrawSettingsTable("##additionalsettingstable", additionalSettings);
                 ImGui.TreePop();
             }
 
@@ -97,7 +97,7 @@ namespace T3.Gui.Windows
 
                 if (ImGui.TreeNode("T3 Ui Style"))
                 {
-                    SettingsUi.DrawSettings(t3UiStyleSettings);
+                    SettingsUi.DrawSettingsTable("##t3uistylesettings", t3UiStyleSettings);
                 }
                 
                 if (ImGui.TreeNode("T3 Graph colors"))

--- a/T3/Gui/Windows/SettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsWindow.cs
@@ -71,7 +71,6 @@ namespace T3.Gui.Windows
                     ImGui.Unindent();
                     ImGui.TreePop();
                 }
-#endif
 
                 if (ImGui.TreeNode("Modified Symbols"))
                 {
@@ -88,7 +87,8 @@ namespace T3.Gui.Windows
                 
                 ImGui.TreePop();
             }
-
+            
+#endif
 #if DEBUG
             if (ImGui.TreeNode("Look (not saved)"))
             {
@@ -116,7 +116,7 @@ namespace T3.Gui.Windows
             }
 #endif
 
-            if(changed)
+            if (changed)
                 UserSettings.Save();
 
 #if DEBUG

--- a/T3/Gui/Windows/SettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsWindow.cs
@@ -38,21 +38,19 @@ namespace T3.Gui.Windows
                 ImGui.TreePop();
             }
 
-            
             if (ImGui.TreeNode("Additional settings"))
             {
                 changed |= DrawSettingsTable("##AdditionalSettings", additionalSettings);
                 ImGui.TreePop();
             }
 
+#if DEBUG
             if (ImGui.TreeNode("Debug Options"))
             {
-                ImGui.Checkbox("VSync", ref UseVSync);
-                ImGui.Checkbox("Show Window Regions", ref WindowRegionsVisible);
-                ImGui.Checkbox("Show Item Regions", ref ItemRegionsVisible);
-
+                DrawSettingsTable("##DebugOptionsTable", debugSettings);
                 if (ImGui.TreeNode("Undo Queue"))
                 {
+                    ImGui.Indent();
                     ImGui.TextUnformatted("Undo");
                     ImGui.Indent();
                     foreach (var c in UndoRedoStack.UndoStack)
@@ -70,9 +68,11 @@ namespace T3.Gui.Windows
                     }
 
                     ImGui.Unindent();
+                    ImGui.Unindent();
                     ImGui.TreePop();
                 }
-                
+#endif
+
                 if (ImGui.TreeNode("Modified Symbols"))
                 {
                     foreach (var symbolUi in UiModel.GetModifiedSymbolUis())
@@ -89,6 +89,7 @@ namespace T3.Gui.Windows
                 ImGui.TreePop();
             }
 
+#if DEBUG
             if (ImGui.TreeNode("Look (not saved)"))
             {
                 ColorVariations.DrawSettingsUi();
@@ -113,12 +114,15 @@ namespace T3.Gui.Windows
                 }                
                 ImGui.TreePop();
             }
-            
+#endif
+
             if(changed)
                 UserSettings.Save();
-            
+
+#if DEBUG
             ImGui.Separator();
             T3Metrics.Draw();
+#endif
         }
 
         public override List<Window> GetInstances()

--- a/T3/Gui/Windows/SettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsWindow.cs
@@ -7,6 +7,7 @@ using T3.Gui.Graph;
 using T3.Gui.TypeColors;
 using T3.Gui.UiHelpers;
 using System.Numerics;
+using t3.Gui;
 
 namespace T3.Gui.Windows
 {
@@ -28,26 +29,26 @@ namespace T3.Gui.Windows
             ImGui.NewLine();
             if (ImGui.TreeNode("User Interface"))
             {
-                changed |= DrawSettingsTable("##UserInterfaceTable", userInterfaceSettings);
+                changed |= SettingsUi.DrawSettings(userInterfaceSettings);
                 ImGui.TreePop();
             }
             
             if (ImGui.TreeNode("Space Mouse"))
             {
-                changed |= DrawSettingsTable("##SpaceMouseTable", spaceMouseSettings);
+                changed |= SettingsUi.DrawSettings(spaceMouseSettings);
                 ImGui.TreePop();
             }
 
             if (ImGui.TreeNode("Additional settings"))
             {
-                changed |= DrawSettingsTable("##AdditionalSettings", additionalSettings);
+                changed |= SettingsUi.DrawSettings(additionalSettings);
                 ImGui.TreePop();
             }
 
 #if DEBUG
             if (ImGui.TreeNode("Debug Options"))
             {
-                DrawSettingsTable("##DebugOptionsTable", debugSettings);
+                SettingsUi.DrawSettings(debugSettings);
                 if (ImGui.TreeNode("Undo Queue"))
                 {
                     ImGui.Indent();
@@ -96,15 +97,7 @@ namespace T3.Gui.Windows
 
                 if (ImGui.TreeNode("T3 Ui Style"))
                 {
-                    ImGui.DragFloat("Height Connection Zone", ref GraphNode.UsableSlotThickness);
-                    ImGui.DragFloat2("Label position", ref GraphNode.LabelPos);
-                    ImGui.DragFloat("Slot Gaps", ref GraphNode.SlotGaps, 0.1f, 0, 10f);
-                    ImGui.DragFloat("Input Slot Margin Y", ref GraphNode.InputSlotMargin, 0.1f, 0, 10f);
-                    ImGui.DragFloat("Input Slot Thickness", ref GraphNode.InputSlotThickness, 0.1f, 0, 10f);
-                    ImGui.DragFloat("Output Slot Margin", ref GraphNode.OutputSlotMargin, 0.1f, 0, 10f);
-
-                    ImGui.ColorEdit4("ValueLabelColor", ref T3Style.Colors.ValueLabelColor.Rgba);
-                    ImGui.ColorEdit4("ValueLabelColorHover", ref T3Style.Colors.ValueLabelColorHover.Rgba);
+                    SettingsUi.DrawSettings(t3UiStyleSettings);
                 }
                 
                 if (ImGui.TreeNode("T3 Graph colors"))
@@ -128,46 +121,6 @@ namespace T3.Gui.Windows
         public override List<Window> GetInstances()
         {
             return new List<Window>();
-        }
-
-        bool DrawSettingsTable(string tableID, UIControlledSetting[] settings)
-        {
-            ImGui.NewLine();
-            bool changed = false;
-            if (ImGui.BeginTable(tableID, 2, ImGuiTableFlags.BordersInnerH | ImGuiTableFlags.SizingFixedSame | ImGuiTableFlags.PadOuterX))
-            {
-                foreach (UIControlledSetting setting in settings)
-                {
-                    ImGui.TableNextRow();
-                    ImGui.TableNextColumn();
-                    ImGui.Indent();
-                    ImGui.Text(setting.label);
-                    ImGui.Unindent();
-
-                    if (!string.IsNullOrEmpty(setting.tooltip))
-                    {
-                        if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        {
-                            ImGui.SetTooltip(setting.tooltip);
-                        }
-                    }
-
-                    ImGui.TableNextColumn();
-
-                    bool valueChanged = setting.imguiFunc.Invoke();
-                    if(valueChanged && setting.OnValueChanged != null)
-                    {
-                        setting.OnValueChanged.Invoke();
-                    }
-
-                    changed |= valueChanged;
-                }
-            }
-
-            ImGui.EndTable();
-            ImGui.NewLine();
-
-            return changed;
         }
     }
 }


### PR DESCRIPTION
So I applied your feedback for the settings UI. ~~It's a little bit awkward imo (i still preferred the table ;))~~ I made it a table this time around too with that final commit. let me know if the way i did it though works a little better, i just found it unpleasant to work with without that

also made a little settings display class to make rendering lists of settings easier

Also made some significant changes to how the SymbolBrowser organizes itself - now it should never clip off of the canvas, and it should stay in view. You can now also be confident the description panel will stay up so you can scroll and pull out examples.

Also did some refactoring for maintainability and editability

sorry this pull request is gigantic lol