### PR TITLE
Improved Settings UI, consistent visibility and usability of SymbolBrowser, some refactoring

### DIFF
--- a/Core/Resource/CollectionUtils.cs
+++ b/Core/Resource/CollectionUtils.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.Resource
+{
+    public static class CollectionUtils
+    {
+        /// <summary>
+        /// A simple method to get a new index by "jumping" from a startIndex
+        /// When the jump would make the index exceed the valid range of the collection,
+        /// it will return an index that "wraps" around the other side
+        /// </summary>
+        /// <param name="startIndex">Index to jump from</param>
+        /// <param name="jumpAmount">How far to jump (usually 1 or -1 for forward and backward respectively)</param>
+        /// <param name="collection">The collection whose Count (Length for arrays) will be referenced</param>
+        /// <param name="realWrap">If false, this will default to making every wrap result in the first or last index of the collection.
+        /// If true, it will be a "real" wrap, where if you jump in excess of X, you will wrap to the index X distance from the other side. </param>
+        /// <returns></returns>
+        public static int WrapIndex(int startIndex, int jumpAmount, System.Collections.IList collection, bool realWrap = false)
+        {
+            int index = startIndex + jumpAmount;
+            index %= collection.Count;
+
+            bool newIndexIsNegative = index < 0;
+            int negativeWrapIndex = realWrap ? collection.Count + index : collection.Count - 1;
+
+            return newIndexIsNegative ? negativeWrapIndex : index;
+        }
+    }
+}

--- a/Core/Resource/MathUtils.cs
+++ b/Core/Resource/MathUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using System.Reflection;
 using T3.Core.Animation;
 using T3.Core.Operator;
 
@@ -144,6 +145,28 @@ namespace T3.Core
             }
 
             return v;
+        }
+
+        /// <summary>
+        /// A simple method to get a new index by "jumping" from a startIndex
+        /// When the jump would make the index exceed the valid range of the collection,
+        /// it will return an index that "wraps" around the other side
+        /// </summary>
+        /// <param name="startIndex">Index to jump from</param>
+        /// <param name="jumpAmount">How far to jump (usually 1 or -1 for forward and backward respectively)</param>
+        /// <param name="collection">The collection whose Count (Length for arrays) will be referenced</param>
+        /// <param name="realWrap">If false, this will default to making every wrap result in the first or last index of the collection.
+        /// If true, it will be a "real" wrap, where if you jump in excess of X, you will wrap to the index X distance from the other side. </param>
+        /// <returns></returns>
+        public static int WrapIndex(int startIndex, int jumpAmount, System.Collections.IList collection, bool realWrap = false)
+        {
+            int index = startIndex + jumpAmount;
+            index %= collection.Count;
+
+            bool newIndexIsNegative = index < 0;
+            int negativeWrapIndex = realWrap ? collection.Count + index : collection.Count - 1;
+
+            return newIndexIsNegative ? negativeWrapIndex : index;
         }
 
         public static Vector2 Min(Vector2 lhs, Vector2 rhs)

--- a/Core/Resource/MathUtils.cs
+++ b/Core/Resource/MathUtils.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Numerics;
-using System.Reflection;
 using T3.Core.Animation;
-using T3.Core.Operator;
 
 namespace T3.Core
 {
@@ -145,28 +143,6 @@ namespace T3.Core
             }
 
             return v;
-        }
-
-        /// <summary>
-        /// A simple method to get a new index by "jumping" from a startIndex
-        /// When the jump would make the index exceed the valid range of the collection,
-        /// it will return an index that "wraps" around the other side
-        /// </summary>
-        /// <param name="startIndex">Index to jump from</param>
-        /// <param name="jumpAmount">How far to jump (usually 1 or -1 for forward and backward respectively)</param>
-        /// <param name="collection">The collection whose Count (Length for arrays) will be referenced</param>
-        /// <param name="realWrap">If false, this will default to making every wrap result in the first or last index of the collection.
-        /// If true, it will be a "real" wrap, where if you jump in excess of X, you will wrap to the index X distance from the other side. </param>
-        /// <returns></returns>
-        public static int WrapIndex(int startIndex, int jumpAmount, System.Collections.IList collection, bool realWrap = false)
-        {
-            int index = startIndex + jumpAmount;
-            index %= collection.Count;
-
-            bool newIndexIsNegative = index < 0;
-            int negativeWrapIndex = realWrap ? collection.Count + index : collection.Count - 1;
-
-            return newIndexIsNegative ? negativeWrapIndex : index;
         }
 
         public static Vector2 Min(Vector2 lhs, Vector2 rhs)

--- a/T3/Gui/Graph/Interaction/SymbolBrowser.cs
+++ b/T3/Gui/Graph/Interaction/SymbolBrowser.cs
@@ -343,17 +343,8 @@ namespace T3.Gui.Graph.Interaction
             var yOverflow = maxYPos > windowSize.Y;
             var yShrinkage = yOverflow ? windowSize.Y - maxYPos : 0;
 
-            position = new Vector2
-            {
-                X = position.X + xPositionOffset,
-                Y = position.Y
-            };
-
-            size = new Vector2
-            {
-                X = size.X,
-                Y = size.Y + yShrinkage
-            };
+            position.X += xPositionOffset;
+            size.Y += yShrinkage;
         }
 
         private void DrawDescriptionPanel(Vector2 position, Vector2 size, SymbolUi itemForHelp)

--- a/T3/Gui/SettingsUi.cs
+++ b/T3/Gui/SettingsUi.cs
@@ -33,15 +33,20 @@ namespace t3.Gui
                     {
                         var valueChanged = setting.DrawGUIControl(true);
                         changed |= valueChanged;
+
                         ImGui.SameLine();
                         ImGui.Dummy(_leftCheckboxSpacing);
                         ImGui.SameLine();
+
                         ImGui.Text(setting.CleanLabel);
+                        DrawTooltip(setting);
+
                         ImGui.Unindent();
                     }
                     else
                     {
                         ImGui.Text(setting.CleanLabel);
+                        DrawTooltip(setting);
                         ImGui.Unindent();
                         ImGui.TableNextColumn();
                         var valueChanged = setting.DrawGUIControl(true);
@@ -71,12 +76,24 @@ namespace t3.Gui
             foreach (var setting in settings)
             {
                 ImGui.Text(setting.CleanLabel);
+                DrawTooltip(setting);
                 ImGui.SameLine();
                 changed |= setting.DrawGUIControl(true);
             }
 
             ImGui.NewLine();
             return changed;
+        }
+
+        private static void DrawTooltip(UIControlledSetting setting)
+        {
+            if (!string.IsNullOrEmpty(setting.Tooltip))
+            {
+                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                {
+                    ImGui.SetTooltip(setting.Tooltip);
+                }
+            }
         }
 
         private static readonly Vector2 _leftCheckboxSpacing = new Vector2(0f, 20f);

--- a/T3/Gui/SettingsUi.cs
+++ b/T3/Gui/SettingsUi.cs
@@ -1,0 +1,84 @@
+using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using T3.Gui.Windows;
+
+namespace t3.Gui
+{
+    public static class SettingsUi
+    {
+        /// <summary>
+        /// Draws a table of <see cref="UIControlledSetting"/>s
+        /// </summary>
+        /// <param name="tableID">Unique identifier for your table - will not be displayed</param>
+        /// <param name="settings">Settings to display</param>
+        /// <returns>Returns true if a setting has been modified</returns>
+        public static bool DrawSettingsTable(string tableID, UIControlledSetting[] settings)
+        {
+            ImGui.NewLine();
+            bool changed = false;
+            if (ImGui.BeginTable(tableID, 2, ImGuiTableFlags.BordersInnerH | ImGuiTableFlags.SizingFixedSame | ImGuiTableFlags.PadOuterX))
+            {
+                foreach (UIControlledSetting setting in settings)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+                    ImGui.Indent();
+
+                    if (setting.DrawOnLeft)
+                    {
+                        var valueChanged = setting.DrawGUIControl(true);
+                        changed |= valueChanged;
+                        ImGui.SameLine();
+                        ImGui.Dummy(_leftCheckboxSpacing);
+                        ImGui.SameLine();
+                        ImGui.Text(setting.CleanLabel);
+                        ImGui.Unindent();
+                    }
+                    else
+                    {
+                        ImGui.Text(setting.CleanLabel);
+                        ImGui.Unindent();
+                        ImGui.TableNextColumn();
+                        var valueChanged = setting.DrawGUIControl(true);
+                        changed |= valueChanged;
+                    }
+
+                }
+            }
+
+            ImGui.EndTable();
+            ImGui.NewLine();
+
+            return changed;
+        }
+
+        /// <summary>
+        /// Draws a series of settings in order
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        public static bool DrawSettings(UIControlledSetting[] settings)
+        {
+            ImGui.NewLine();
+
+            bool changed = false;
+
+            foreach (var setting in settings)
+            {
+                ImGui.Text(setting.CleanLabel);
+                ImGui.SameLine();
+                changed |= setting.DrawGUIControl(true);
+            }
+
+            ImGui.NewLine();
+            return changed;
+        }
+
+        private static readonly Vector2 _leftCheckboxSpacing = new Vector2(0f, 20f);
+    }
+}

--- a/T3/Gui/Styling/CustomComponents.cs
+++ b/T3/Gui/Styling/CustomComponents.cs
@@ -492,18 +492,6 @@ namespace T3.Gui
             return modified;
         }
 
-        public static bool FloatValueEditInPlace(string label, ref float value, float min = float.NegativeInfinity, float max = float.PositiveInfinity, float scale = 0.01f, bool clamp = false)
-        {
-            string cleanedLabel = label.Split(_idSpecifier)[0];
-            ImGui.TextUnformatted(cleanedLabel);
-            ImGui.SameLine();
-            ImGui.PushID(label);
-            var modified = DrawSingleValueEdit(cleanedLabel, ref value, min, max, clamp, scale);
-
-            ImGui.PopID();
-            return modified;
-        }
-
         public static bool IntValueEdit(string label, ref int value, int min = int.MinValue, int max = int.MaxValue, float scale = 1)
         {
             var labelSize = ImGui.CalcTextSize(label);

--- a/T3/Gui/Styling/CustomComponents.cs
+++ b/T3/Gui/Styling/CustomComponents.cs
@@ -473,22 +473,33 @@ namespace T3.Gui
         }
 
 
-        public static bool FloatValueEdit(string label, ref float value, float min= float.NegativeInfinity, float max= float.PositiveInfinity, float scale= 0)
+        public static bool FloatValueEdit(string label, ref float value, float min = float.NegativeInfinity, float max = float.PositiveInfinity, float scale = 0.01f, bool clamp = false)
         {
             var labelSize = ImGui.CalcTextSize(label);
             const float leftPadding = 200;
             var p = ImGui.GetCursorPos();
-            ImGui.SetCursorPosX( MathF.Max(leftPadding - labelSize.X,0)+10);
+            ImGui.SetCursorPosX(MathF.Max(leftPadding - labelSize.X, 0) + 10);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(label);
+
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
             ImGui.SetCursorPos(p);
-            
+
             ImGui.SameLine();
             ImGui.SetCursorPosX(leftPadding + 20);
-            var size = new Vector2(150, ImGui.GetFrameHeight());
+            var modified = DrawSingleValueEdit(cleanedLabel, ref value, min, max, clamp, scale);
+
+            return modified;
+        }
+
+        public static bool FloatValueEditInPlace(string label, ref float value, float min = float.NegativeInfinity, float max = float.PositiveInfinity, float scale = 0.01f, bool clamp = false)
+        {
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
+            ImGui.SameLine();
             ImGui.PushID(label);
-            var result = SingleValueEdit.Draw(ref value, size, min, max);
-            var modified = (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
+            var modified = DrawSingleValueEdit(cleanedLabel, ref value, min, max, clamp, scale);
+
             ImGui.PopID();
             return modified;
         }
@@ -500,17 +511,35 @@ namespace T3.Gui
             var p = ImGui.GetCursorPos();
             ImGui.SetCursorPosX(MathF.Max(leftPadding - labelSize.X, 0) + 10);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(label);
+
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
+
             ImGui.SetCursorPos(p);
 
             ImGui.SameLine();
             ImGui.SetCursorPosX(leftPadding + 20);
-            var size = new Vector2(150, ImGui.GetFrameHeight());
-            ImGui.PushID(label);
-            var result = SingleValueEdit.Draw(ref value, size, min, max, true, scale);
-            var modified = (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
-            ImGui.PopID();
+
+            var modified = DrawSingleValueEdit(cleanedLabel, ref value, min, max, true, scale);
             return modified;
+        }
+
+        public static bool DrawSingleValueEdit(string label, ref int value, int min = int.MinValue, int max = int.MaxValue, bool clamp = false, float scale = 1f)
+        {
+            ImGui.PushID(label);
+            var size = new Vector2(150, ImGui.GetFrameHeight());
+            var result = SingleValueEdit.Draw(ref value, size, min, max, clamp, scale);
+            ImGui.PopID();
+            return (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
+        }
+
+        public static bool DrawSingleValueEdit(string label, ref float value, float min = float.MinValue, float max = float.MaxValue, bool clamp = false, float scale = 1f)
+        {
+            ImGui.PushID(label);
+            var size = new Vector2(150, ImGui.GetFrameHeight());
+            var result = SingleValueEdit.Draw(ref value, size, min, max, clamp, scale);
+            ImGui.PopID();
+            return (result & InputEditStateFlags.Modified) != InputEditStateFlags.Nothing;
         }
 
         public static bool StringValueEdit(string label, ref string value)
@@ -521,7 +550,10 @@ namespace T3.Gui
             var p = ImGui.GetCursorPos();
             ImGui.SetCursorPosX( MathF.Max(leftPadding - labelSize.X,0)+10);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(label);
+
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
+
             ImGui.SetCursorPos(p);
             
             ImGui.SameLine();
@@ -541,7 +573,10 @@ namespace T3.Gui
             var p = ImGui.GetCursorPos();
             ImGui.SetCursorPosX(MathF.Max(200 - labelSize.X, 0) + 10);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(label);
+
+            string cleanedLabel = label.Split(_idSpecifier)[0];
+            ImGui.TextUnformatted(cleanedLabel);
+
             ImGui.SetCursorPos(p);
 
             // Dropdown
@@ -567,6 +602,8 @@ namespace T3.Gui
             var modified = ImGui.Combo($"##dropDown{enumType}{label}", ref index, valueNames, valueNames.Length, valueNames.Length);
             return modified;
         }
+
+        private const string _idSpecifier = "##";
     }
 
     public static class InputWithTypeAheadSearch
@@ -665,6 +702,6 @@ namespace T3.Gui
 
         private static List<string> _lastResults = new List<string>();
         private static int _selectedResultIndex = 0;
-        private static bool _isSearchResultWindowOpen;        
+        private static bool _isSearchResultWindowOpen;
     }
 }

--- a/T3/Gui/UiHelpers/UIControlledSetting.cs
+++ b/T3/Gui/UiHelpers/UIControlledSetting.cs
@@ -18,7 +18,7 @@ namespace T3.Gui.Windows
         public string CleanLabel { get; private set; }
         public bool DrawOnLeft { get; private set; }
 
-        private string _tooltip;
+        public string Tooltip { get; private set; }
         private string _additionalNotes;
         private Func<string, bool> _guiFunc;
         private Action _OnValueChanged;
@@ -53,7 +53,7 @@ namespace T3.Gui.Windows
             _uniqueLabel = $"{label}##{_countForUniqueID--}";
 
             _guiFunc = guiFunc;
-            _tooltip = tooltip;
+            Tooltip = tooltip;
             _additionalNotes = additionalNotes;
             _OnValueChanged = OnValueChanged;
             DrawOnLeft = drawOnLeft;
@@ -66,17 +66,9 @@ namespace T3.Gui.Windows
         /// If an Action was provided in constructor, it will be executed when value is changed. </returns>
         public bool DrawGUIControl(bool hideLabel)
         {
-            if (!string.IsNullOrEmpty(_tooltip))
-            {
-                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                {
-                    ImGui.SetTooltip(_tooltip);
-                }
-            }
-
             var changed = DrawCommand(hideLabel);
 
-            if(changed)
+            if (changed)
             {
                 _OnValueChanged?.Invoke();
             }

--- a/T3/Gui/UiHelpers/UIControlledSetting.cs
+++ b/T3/Gui/UiHelpers/UIControlledSetting.cs
@@ -1,0 +1,92 @@
+using ImGuiNET;
+using System;
+using T3.Gui.UiHelpers;
+
+namespace T3.Gui.Windows
+{
+    public class UIControlledSetting
+    {
+        /// <summary>
+        /// The generated unique label
+        /// </summary>
+        private string _uniqueLabel;
+        private string _hiddenUniqueLabel;
+
+        /// <summary>
+        /// The label provided in the constructor
+        /// </summary>
+        public string CleanLabel { get; private set; }
+        public bool DrawOnLeft { get; private set; }
+
+        private string _tooltip;
+        private string _additionalNotes;
+        private Func<string, bool> _guiFunc;
+        private Action _OnValueChanged;
+
+        // Cheaper than GUIDs
+        // In case we want to have the same variable be changeable with different UI controls
+        // or if multiple settings have the same label
+        static ushort _countForUniqueID = ushort.MaxValue;
+
+        /// <summary>
+        /// For the sake of simple use of the optional parameters and populating/maintaining many settings, the recommended way to call this constructor is:
+        /// <code>
+        /// new UIControlledSetting
+        /// (
+        ///    label: "My Setting",
+        ///    tooltip: "The global scale of all rendered UI in the application",
+        ///    guiFunc: (string guiLabel) => CustomComponents.FloatValueEdit(guiLabel, ref UserSettings.Config.UiScaleFactor, 0.01f, 0.5f, 3f),
+        ///    OnValueChanged: () => //your action
+        /// );
+        /// </code>
+        /// </summary>
+        /// <param name="label">The label to display next to the gui control</param>
+        /// <param name="guiFunc">The <see cref="ImGuiNET"/> - based function that draws the setting control and
+        /// returns true if the control was changed. The input to this function see is a unique ID based on the label provided</param>
+        /// <param name="tooltip">Tooltip displayed when hovering over the control</param>
+        /// <param name="additionalNotes">Additional notes displayed alongside the tooltip [Not currently in use, but will be once T3 tooltips are integrated]</param>
+        /// <param name="OnValueChanged">An action performed when the value is changed</param>
+        public UIControlledSetting(string label, Func<string, bool> guiFunc, string tooltip = null, string additionalNotes = null, bool drawOnLeft = false, Action OnValueChanged = null)
+        {
+            CleanLabel = label;
+            _hiddenUniqueLabel = $"##{label}{_countForUniqueID--}";
+            _uniqueLabel = $"{label}##{_countForUniqueID--}";
+
+            _guiFunc = guiFunc;
+            _tooltip = tooltip;
+            _additionalNotes = additionalNotes;
+            _OnValueChanged = OnValueChanged;
+            DrawOnLeft = drawOnLeft;
+        }
+
+        /// <summary>
+        /// Draws the GUI for this setting using the Func provided in its constructor
+        /// </summary>
+        /// <returns>True if changed, false if unchanged.
+        /// If an Action was provided in constructor, it will be executed when value is changed. </returns>
+        public bool DrawGUIControl(bool hideLabel)
+        {
+            if (!string.IsNullOrEmpty(_tooltip))
+            {
+                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                {
+                    ImGui.SetTooltip(_tooltip);
+                }
+            }
+
+            var changed = DrawCommand(hideLabel);
+
+            if(changed)
+            {
+                _OnValueChanged?.Invoke();
+            }
+
+            return changed;
+        }
+
+        bool DrawCommand(bool hideLabel)
+        {
+            return _guiFunc.Invoke(hideLabel ? _hiddenUniqueLabel : _uniqueLabel);
+        }
+    }
+}

--- a/T3/Gui/UiHelpers/UserSettings.cs
+++ b/T3/Gui/UiHelpers/UserSettings.cs
@@ -56,6 +56,7 @@ namespace T3.Gui.UiHelpers
             public float ScrollSmoothing = 0.06f;
             public float TooltipDelay = 1.2f;
             public float ClickThreshold = 5; // Increase for high-res display and pen tablets
+            public bool SymbolBrowserDescriptionTimeout = false;
 
             public float KeyboardScrollAcceleration = 2.5f;
 

--- a/T3/Gui/UiHelpers/UserSettings.cs
+++ b/T3/Gui/UiHelpers/UserSettings.cs
@@ -56,7 +56,6 @@ namespace T3.Gui.UiHelpers
             public float ScrollSmoothing = 0.06f;
             public float TooltipDelay = 1.2f;
             public float ClickThreshold = 5; // Increase for high-res display and pen tablets
-            public bool SymbolBrowserDescriptionTimeout = false;
 
             public float KeyboardScrollAcceleration = 2.5f;
 
@@ -79,6 +78,9 @@ namespace T3.Gui.UiHelpers
             public float SpaceMouseRotationSpeedFactor = 1f;
             public float SpaceMouseMoveSpeedFactor = 1f;
             public float SpaceMouseDamping = 0.5f;
+
+            // Symbol Browser
+            public bool AlwaysShowDescriptionPanel = false;
 
             [JsonConverter(typeof(StringEnumConverter))]
             public TimeFormat.TimeDisplayModes TimeDisplayMode = TimeFormat.TimeDisplayModes.Bars;

--- a/T3/Gui/Windows/SettingsInSettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsInSettingsWindow.cs
@@ -1,0 +1,219 @@
+using ImGuiNET;
+using System;
+using System.Numerics;
+using T3.Gui.Graph;
+using T3.Gui.UiHelpers;
+
+namespace T3.Gui.Windows
+{
+    public partial class SettingsWindow
+    {
+        static readonly UIControlledSetting[] userInterfaceSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting
+            (
+                label: "Warn before Lib modifications",
+                tooltip: "This warning pops up when you attempt to enter an Operator that ships with the application.\n" +
+                         "If unsure, this is best left checked.",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.WarnBeforeLibEdit),
+                drawOnLeft: true
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Use arc connections",
+                tooltip: "Affects the shape of the connections between your Operators",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.UseArcConnections),
+                drawOnLeft: true
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Use Jog Dial Control",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.UseJogDialControl),
+                drawOnLeft: true
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Show Graph thumbnails",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowThumbnails),
+                drawOnLeft: true
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Drag snapped nodes",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SmartGroupDragging),
+                drawOnLeft: true
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Fullscreen Window Swap",
+                tooltip: "Swap main and second windows when fullscreen",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.SwapMainAnd2ndWindowsWhenFullscreen),
+                drawOnLeft: true
+            ),
+
+            new UIControlledSetting
+            (
+                label: "UI Scale",
+                tooltip: "The global scale of all rendered UI in the application",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.UiScaleFactor, 0.1f, 5f, true, 0.01f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Scroll smoothing",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.ScrollSmoothing, 0f, 0.2f, true, 0.01f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Snap strength",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.SnapStrength)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Click threshold",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.ClickThreshold)
+
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Timeline Raster Density",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.TimeRasterDensity)
+            ),
+        };
+
+        static readonly UIControlledSetting[] spaceMouseSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting
+            (
+                label: "Smoothing",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseDamping, 0.01f, 1f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Move Speed",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseMoveSpeedFactor, 0, 10f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Rotation Speed",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.SpaceMouseRotationSpeedFactor, 0, 10f)
+            )
+        };
+
+        static readonly UIControlledSetting[] additionalSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting
+            (
+                label: "Gizmo size",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.GizmoSize)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Tooltip delay",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref UserSettings.Config.TooltipDelay)
+            ),
+
+
+            // These settings were laid out in the old UI, kept here for someone else to ultimately choose to yeet or unyeet them
+
+            //new UIControlledSetting
+            //(
+            //    label: "Show Title",
+            //    guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowTitleAndDescription)
+            //),
+
+            //new UIControlledSetting
+            //(
+            //    label: "Show Timeline",
+            //    guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.ShowTimeline)
+            //)
+        };
+        
+        static readonly UIControlledSetting[] debugSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting
+            (
+                label: "VSync",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UseVSync),
+                drawOnLeft: true
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Show Window Regions",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref WindowRegionsVisible),
+                drawOnLeft: true
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Show Item Regions",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref ItemRegionsVisible),
+                drawOnLeft: true
+            ),
+        };
+
+        static readonly UIControlledSetting[] t3UiStyleSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting
+            (
+                label: "Label position",
+                guiFunc: (string guiLabel) => ImGui.DragFloat2(guiLabel, ref GraphNode.LabelPos)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Height Connection Zone",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.UsableSlotThickness)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Slot Gaps",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.SlotGaps, 0, 10f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Input Slot Margin Y",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.InputSlotMargin, 0, 10f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Input Slot Thickness",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.InputSlotThickness, 0, 10f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Output Slot Margin",
+                guiFunc: (string guiLabel) => CustomComponents.DrawSingleValueEdit(guiLabel, ref GraphNode.OutputSlotMargin, 0, 10f)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Value Label Color",
+                guiFunc: (string guiLabel) => ImGui.ColorEdit4(guiLabel, ref T3Style.Colors.ValueLabelColor.Rgba)
+            ),
+
+            new UIControlledSetting
+            (
+                label: "Value Label Color Hover",
+                guiFunc: (string guiLabel) => ImGui.ColorEdit4(guiLabel, ref T3Style.Colors.ValueLabelColorHover.Rgba)
+            ),
+        };
+
+    }
+}

--- a/T3/Gui/Windows/SettingsInSettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsInSettingsWindow.cs
@@ -215,5 +215,17 @@ namespace T3.Gui.Windows
             ),
         };
 
+        static readonly UIControlledSetting[] symbolBrowserSettings = new UIControlledSetting[]
+        {
+            new UIControlledSetting
+            (
+                label: "Always Show Description",
+                tooltip: "Shifts the Description panel to the left of the Symbol Browser when\n" +
+                        "it is too close to the right edge of the screen to display it.",
+                guiFunc: (string guiLabel) => ImGui.Checkbox(guiLabel, ref UserSettings.Config.AlwaysShowDescriptionPanel),
+                drawOnLeft: true
+            ),
+        };
+
     }
 }

--- a/T3/Gui/Windows/SettingsWindow.cs
+++ b/T3/Gui/Windows/SettingsWindow.cs
@@ -39,9 +39,15 @@ namespace T3.Gui.Windows
                 ImGui.TreePop();
             }
 
-            if (ImGui.TreeNode("Additional settings"))
+            if (ImGui.TreeNode("Additional Settings"))
             {
                 changed |= SettingsUi.DrawSettingsTable("##additionalsettingstable", additionalSettings);
+
+                if(ImGui.TreeNode("Symbol Browser Settings"))
+                {
+                    changed |= SettingsUi.DrawSettingsTable("##symbolbrowsersettingstable", symbolBrowserSettings);
+                }
+
                 ImGui.TreePop();
             }
 


### PR DESCRIPTION
So I applied your feedback for the settings UI. ~~It's a little bit awkward imo (i still preferred the table ;))~~ I made it a table this time around too with that final commit. let me know if the way i did it though works a little better, i just found it unpleasant to work with without that

also made a little settings display class to make rendering lists of settings easier

Also made some significant changes to how the SymbolBrowser organizes itself - now it should never clip off of the canvas, and it should stay in view. You can now also be confident the description panel will stay up so you can scroll and pull out examples.

Also did some refactoring for maintainability and editability
