### PR TITLE
Fixed standalone version compilation issues

### DIFF
--- a/Operators/RequiredOps.md
+++ b/Operators/RequiredOps.md
@@ -67,6 +67,9 @@ SampleGradient_8211249d-7a26-4ad0-8d84-56da72a5c536.t3ui
 SoundInput.cs
 SoundInput_b72d968b-0045-408d-a2f9-5c739c692a66.t3
 SoundInput_b72d968b-0045-408d-a2f9-5c739c692a66.t3ui
+SpoutOutput.cs
+SpoutOutput_13be1e3f-861d-4350-a94e-e083637b3e55.t3
+SpoutOutput_13be1e3f-861d-4350-a94e-e083637b3e55.t3ui
 String.cs
 String_5880cbc3-a541-4484-a06a-0e6f77cdbe8e.t3
 String_5880cbc3-a541-4484-a06a-0e6f77cdbe8e.t3ui

--- a/StartT3/Program.cs
+++ b/StartT3/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -105,7 +105,8 @@ namespace StartEditor
                                                        syntaxTrees,
                                                        referencedAssemblies.ToArray(),
                                                        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                                                          .WithOptimizationLevel(OptimizationLevel.Release));
+                                                          .WithOptimizationLevel(OptimizationLevel.Release)
+                                                          .WithAllowUnsafe(true));
 
             using (var dllStream = new FileStream(FinalOperatorAssemblyFilepath, FileMode.Create)) 
             // using (var pdbStream = new FileStream(exportPath + Path.DirectorySeparatorChar + "Operators.pdb", FileMode.Create))

--- a/StartT3/StartT3.csproj
+++ b/StartT3/StartT3.csproj
@@ -11,11 +11,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CppSharp" Version="1.0.1" />
     <PackageReference Include="ManagedBass" Version="3.1.0" />
     <PackageReference Include="ManagedBass.Wasapi" Version="3.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="NAudio" Version="2.1.0" />
     <PackageReference Include="NAudio.Midi" Version="2.1.0" />
+    <PackageReference Include="OpenGL.Net" Version="0.8.4">
+        <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <PackageReference Include="Rug.Osc" Version="1.2.5">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>


### PR DESCRIPTION
* Operators had to be compiled with /unsafe option
* Some dependencies (OpenGL, CppSharp) were missing in the StartT3 project